### PR TITLE
fix(ci): don't mistake shell builtin `continue` for the Continue CLI; realpath /tmp in executor test

### DIFF
--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,4 +1,6 @@
 import { execa } from "execa";
+import { stat } from "node:fs/promises";
+import { delimiter, join } from "node:path";
 import { claudeAdapter } from "./claude-code.js";
 import { codexAdapter } from "./codex.js";
 import { cursorAdapter } from "./cursor.js";
@@ -27,14 +29,31 @@ export const ADAPTERS: AiAdapter[] = [
 ];
 
 async function onPath(bin: string): Promise<boolean> {
-  const cmd = process.platform === "win32" ? "where" : "command";
-  const args = process.platform === "win32" ? [bin] : ["-v", bin];
-  try {
-    const r = await execa(cmd, args, { reject: false, shell: process.platform !== "win32" });
-    return r.exitCode === 0 && !!r.stdout.trim();
-  } catch {
-    return false;
+  // Walk PATH directly instead of shelling out to `command -v` / `where`.
+  // `command -v` in sh/bash reports shell builtins (e.g. `continue`) as
+  // found, which would falsely match our Continue.dev adapter on every
+  // system that has bash. A filesystem check avoids that collision and is
+  // also cheaper than spawning a subshell.
+  const pathEnv = process.env.PATH ?? "";
+  if (!pathEnv) return false;
+  const exts = process.platform === "win32"
+    ? (process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM").split(";").map((e) => e.toLowerCase())
+    : [""];
+  for (const dir of pathEnv.split(delimiter)) {
+    if (!dir) continue;
+    for (const ext of exts) {
+      try {
+        const full = join(dir, bin + ext);
+        const st = await stat(full);
+        if (!st.isFile()) continue;
+        if (process.platform === "win32") return true;
+        if (st.mode & 0o111) return true;
+      } catch {
+        /* not found, keep looking */
+      }
+    }
   }
+  return false;
 }
 
 /**

--- a/tests/executor.test.ts
+++ b/tests/executor.test.ts
@@ -1,3 +1,4 @@
+import { realpathSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { execShell } from "../src/router/executor.js";
 
@@ -21,8 +22,11 @@ describe("execShell", () => {
   });
 
   it("respects cwd", async () => {
+    // On macOS `/tmp` is a symlink to `/private/tmp`, so `pwd` reports the
+    // physical path. Compare against the resolved path to stay portable.
+    const expected = realpathSync("/tmp");
     const r = await execShell("pwd", { cwd: "/tmp", captureOnly: true });
-    expect(r.stdout.trim()).toBe("/tmp");
+    expect(r.stdout.trim()).toBe(expected);
   });
 
   it("passes env vars", async () => {


### PR DESCRIPTION
- adapters: walk PATH on the filesystem instead of `command -v`. `command -v continue` returns 0 in sh/bash because `continue` is a shell builtin, so detectAiTool() was reporting a tool installed on every system — breaking the fallback test that depends on "no tool on PATH".
- tests/executor: compare cwd against realpath("/tmp"). macOS resolves /tmp → /private/tmp via symlink, so `pwd` returned the physical path on CI.

https://claude.ai/code/session_01CeDS5W8W9gQQn7RToQJWhZ