### PR TITLE
feat(rules): expand coverage with 10 new domains; clarify interactive session usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,25 @@ unchanged, uninterrupted.
 ---
 
 ```console
-$ claude "git status"
+# One-shot invocations (shell wrapper). Type these at your OS terminal:
+you@host:~/app$ claude -p "git status"
 On branch main
 nothing to commit, working tree clean
 ninja saved ~512 tokens (git-status)
 
-$ claude "what's using port 3000"
+you@host:~/app$ claude -p "what's using port 3000"
 COMMAND  PID  USER   FD   TYPE  DEVICE  SIZE/OFF NODE NAME
 node    4812  alice  21u  IPv6  154321       0t0 TCP  *:3000 (LISTEN)
 ninja saved ~438 tokens (port-usage)
 
-$ claude "explain this stack trace: …"
+you@host:~/app$ claude -p "explain this stack trace: …"
 # not a deterministic command — passes straight through to real claude
 ```
+
+For interactive sessions (`claude`, `cursor-agent`, etc. without args), register
+token-ninja as an **MCP server** instead — see [MCP integration](#mcp-integration).
+The agent then consults the router before every shell call, inside the same
+REPL you already use.
 
 No prefix. No mental overhead. Keep calling `claude`, `codex`, `cursor`, `aider`,
 `gemini`, `continue` — token-ninja quietly handles the boring stuff and gets out
@@ -117,12 +123,14 @@ Everything else falls through to the AI, unchanged.
 ## Quickstart
 
 ```bash
-# After install, use your AI tool normally. token-ninja handles it transparently:
-claude "git status"             # 0 tokens
-claude "build the project"      # 0 tokens (reads package.json / Cargo.toml / …)
-claude "what branch am I on"    # 0 tokens (natural language → git branch --show-current)
-claude "rm -rf /"               # blocked — falls back to real claude for human review
-claude "explain this error: …"  # no match — passes straight through
+# One-shot mode — type these at your OS terminal (bash/zsh/fish), not inside
+# Claude Code's REPL. token-ninja's shell shim wraps the `claude` binary on
+# your PATH, inspects the argument, and runs matched commands locally:
+claude -p "git status"             # 0 tokens
+claude -p "build the project"      # 0 tokens (reads package.json / Cargo.toml / …)
+claude -p "what branch am I on"    # 0 tokens (natural language → git branch --show-current)
+claude -p "rm -rf /"               # blocked — falls back to real claude for human review
+claude -p "explain this error: …"  # no match — passes straight through
 
 # Or invoke ninja directly — same router:
 ninja "show recent commits"
@@ -130,6 +138,12 @@ ninja "show recent commits"
 # See the damage report
 ninja stats
 ```
+
+> **Interactive Claude Code sessions** (running `claude` with no args and typing
+> commands at the REPL) bypass the shell shim by design — once the REPL owns
+> your terminal, the shim can't see what you type. For that workflow, add
+> `ninja mcp` as an MCP server in your Claude Code config. See
+> [MCP integration](#mcp-integration) below.
 
 Re-run auto-setup any time: `ninja setup` · Preview without writing:
 `ninja setup --dry-run` · Scope to specific tools: `ninja setup --tool claude`.
@@ -171,11 +185,18 @@ dangerous command past the classifier.
 
 ## Features
 
-- **472 built-in rules** across **29 tool domains** — git, GitHub CLI, npm,
-  pnpm, yarn, bun, cargo, go, rust, java, kotlin, python, ruby, php, docker,
-  kubernetes, database, network, filesystem, archive, process management, test
-  runners, linters, text processing, build tools, editors, shell utilities,
-  system info, and natural-language mappings.
+- **Hundreds of built-in rules** across dozens of tool domains — git, GitHub
+  CLI, npm, pnpm, yarn, bun, cargo, go, rust, java, kotlin, python, ruby, php,
+  docker, kubernetes, database, network, filesystem, archive, process
+  management, test runners, linters, text processing, build tools, editors,
+  shell utilities, system info, **cloud CLIs (AWS, Azure, gcloud, Vercel,
+  Netlify, Heroku, Fly, Railway, doctl)**, **IaC (Terraform, Ansible, Vagrant,
+  Pulumi, Packer, CDK)**, **bundlers (Vite, Turbo, esbuild, Parcel, Rollup,
+  Webpack, Rspack, tsup, Nx)**, **Deno / Elixir / Dart / Flutter**, **process
+  supervisors (pm2, systemctl --user, journalctl, overmind)**, **env managers
+  (direnv, asdf, mise, pyenv, rbenv, nix, conda)**, **distributed systems
+  (consul, etcd, zookeeper, NATS, Kafka, RabbitMQ)**, and natural-language
+  mappings. Run `ninja rules list` to see everything loaded.
 - **Fast**: ~37 µs per classification, ~4 µs per safety check (warm JIT).
 - **Safe by construction**: layered deny-list blocks `rm -rf /`, `sudo`,
   `git push --force`, `DROP TABLE`, `curl | sh`, `dd if=`, `mkfs`, … including
@@ -285,13 +306,35 @@ Use `ninja rules test "your command"` to dry-run the classifier against any inpu
 
 ## MCP integration
 
+Interactive agents (Claude Code REPL, Cursor, Claude Desktop, Continue, …)
+don't go through the shell shim — they call shell commands *from inside* the
+agent. Register token-ninja as an MCP server and the agent can consult the
+router on every command **before** it burns tokens.
+
 ```bash
 ninja mcp    # stdio server exposing maybe_execute_locally
 ```
 
-Point your MCP-capable AI client (Claude Desktop, Cursor, etc.) at this
-command. On each call the model can ask the router "can you handle this
-locally?" *before* burning tokens. The response:
+**Claude Code** — register once per project (`.mcp.json`) or globally
+(`~/.claude.json`):
+
+```jsonc
+{
+  "mcpServers": {
+    "token-ninja": {
+      "command": "ninja",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Equivalent one-liner: `claude mcp add token-ninja ninja mcp`.
+
+**Cursor / Claude Desktop** — same shape, under their respective
+`mcpServers` settings. Any MCP-capable client works.
+
+Each call the model makes looks like:
 
 ```jsonc
 // handled locally

--- a/README.md
+++ b/README.md
@@ -104,10 +104,14 @@ That's it. A postinstall hook runs `ninja setup`, which:
 1. detects your shell (`bash` / `zsh` / `fish`),
 2. detects any of `claude`, `codex`, `cursor-agent`, `aider`, `gemini`,
    `continue` on your `PATH`,
-3. appends a small managed block to your rc file so calls to those tools route
-   through `ninja` first,
-4. backs up your rc file once to `~/.zshrc.token-ninja.bak` (or equivalent),
-5. writes a default config to `~/.config/token-ninja/config.yaml`.
+3. appends a small managed block to your rc file so one-shot calls to those
+   tools route through `ninja` first,
+4. **registers `ninja mcp` as an MCP server** in Claude Code
+   (`~/.claude.json`), Cursor (`~/.cursor/mcp.json`), and Claude Desktop, so
+   **interactive** agent sessions also benefit without any manual config,
+5. backs up every file it touches once (`*.token-ninja.bak`) before the first
+   write, and skips targets where the config is malformed,
+6. writes a default config to `~/.config/token-ninja/config.yaml`.
 
 **Open a new terminal and keep using your AI tool as before.** Matched commands
 run locally and print a one-line hint like `ninja saved ~512 tokens (git-status)`.
@@ -118,7 +122,11 @@ Everything else falls through to the AI, unchanged.
 > **Opt out of the postinstall hook:**
 > `TOKEN_NINJA_SKIP_POSTINSTALL=1 npm install -g token-ninja`
 >
-> **Roll back any time:** `ninja uninstall` — strips the managed block cleanly.
+> **Opt out of MCP auto-registration only** (keep the shell shim):
+> `ninja setup --no-mcp`
+>
+> **Roll back any time:** `ninja uninstall` — strips the managed block and
+> removes the MCP entry from each client config it wrote to.
 
 ## Quickstart
 
@@ -141,9 +149,11 @@ ninja stats
 
 > **Interactive Claude Code sessions** (running `claude` with no args and typing
 > commands at the REPL) bypass the shell shim by design — once the REPL owns
-> your terminal, the shim can't see what you type. For that workflow, add
-> `ninja mcp` as an MCP server in your Claude Code config. See
-> [MCP integration](#mcp-integration) below.
+> your terminal, the shim can't see what you type. `ninja setup` handles that
+> for you automatically by registering `ninja mcp` as an MCP server in
+> `~/.claude.json`, `~/.cursor/mcp.json`, and Claude Desktop's config.
+> Open a fresh REPL after install and it's already wired up. See
+> [MCP integration](#mcp-integration) for the details.
 
 Re-run auto-setup any time: `ninja setup` · Preview without writing:
 `ninja setup --dry-run` · Scope to specific tools: `ninja setup --tool claude`.
@@ -308,15 +318,16 @@ Use `ninja rules test "your command"` to dry-run the classifier against any inpu
 
 Interactive agents (Claude Code REPL, Cursor, Claude Desktop, Continue, …)
 don't go through the shell shim — they call shell commands *from inside* the
-agent. Register token-ninja as an MCP server and the agent can consult the
+agent. Registering `token-ninja` as an MCP server lets the agent consult the
 router on every command **before** it burns tokens.
 
-```bash
-ninja mcp    # stdio server exposing maybe_execute_locally
-```
+**You don't need to configure this manually.** `ninja setup` (the postinstall
+hook) merges an entry like the one below into:
 
-**Claude Code** — register once per project (`.mcp.json`) or globally
-(`~/.claude.json`):
+- `~/.claude.json` (Claude Code)
+- `~/.cursor/mcp.json` (Cursor)
+- `~/Library/Application Support/Claude/claude_desktop_config.json` (Claude
+  Desktop, macOS — Windows and Linux paths are handled too)
 
 ```jsonc
 {
@@ -329,10 +340,16 @@ ninja mcp    # stdio server exposing maybe_execute_locally
 }
 ```
 
-Equivalent one-liner: `claude mcp add token-ninja ninja mcp`.
+Existing entries are preserved; each file is backed up once
+(`*.token-ninja.bak`) before the first modification. To opt out:
+`ninja setup --no-mcp`. To remove just the MCP entries: `ninja uninstall`.
 
-**Cursor / Claude Desktop** — same shape, under their respective
-`mcpServers` settings. Any MCP-capable client works.
+If you still want to do it yourself — e.g. a project-local `.mcp.json` or an
+MCP client we don't know about — the manual command is:
+
+```bash
+ninja mcp    # stdio server exposing maybe_execute_locally
+```
 
 Each call the model makes looks like:
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,11 +44,12 @@ program
 
 program
   .command("setup")
-  .description("Auto-install: detect AI tools, write shell shims into your rc file, create config")
+  .description("Auto-install: detect AI tools, write shell shims into your rc file, register ninja mcp with MCP-capable clients, create config")
   .option("--shell <name>", "shell to target (bash|zsh|fish); auto-detect by default")
   .option("--tool <id>", "hook a specific tool (repeatable); default = all detected", collect, [])
+  .option("--no-mcp", "skip auto-registering ninja mcp with Claude Code / Cursor / Claude Desktop")
   .option("--quiet", "minimal output", false)
-  .action(async (opts: { shell?: string; tool: string[]; quiet: boolean }, cmd) => {
+  .action(async (opts: { shell?: string; tool: string[]; mcp: boolean; quiet: boolean }, cmd) => {
     // The program-level `--dry-run` is hoisted by commander; merge so users
     // can pass it either before or after the subcommand name.
     const merged = cmd.optsWithGlobals();
@@ -56,6 +57,7 @@ program
       shell: opts.shell,
       tools: opts.tool,
       dryRun: merged.dryRun === true,
+      noMcp: opts.mcp === false,
       quiet: opts.quiet,
     });
     process.exit(code);

--- a/src/router/classifier.ts
+++ b/src/router/classifier.ts
@@ -21,18 +21,21 @@ export async function classify(
     if (cmd) return { rule: exact, command: cmd, matchedVia: "exact" };
   }
 
-  // 2. prefix (longest prefix wins so "git commit -am" beats "git commit")
+  // 2. prefix (longest prefix wins so "git commit -am" beats "git commit").
+  // Candidates are bucketed by the first whitespace-delimited token of the
+  // pattern so a single input only scans rules that share its first word.
   let bestPrefix: { rule: Rule; pattern: string; args: string } | null = null;
-  for (const rule of rules.prefixRules) {
-    if (rule.match.type !== "prefix") continue;
-    for (const p of rule.match.patterns) {
-      const pat = normalizeWhitespace(p);
-      if (input === pat || input.startsWith(pat + " ")) {
-        if (!bestPrefix || pat.length > bestPrefix.pattern.length) {
+  const firstSpace = input.indexOf(" ");
+  const firstWord = firstSpace === -1 ? input : input.slice(0, firstSpace);
+  const candidates = rules.prefixByFirstWord.get(firstWord);
+  if (candidates) {
+    for (const { rule, pattern } of candidates) {
+      if (input === pattern || input.startsWith(pattern + " ")) {
+        if (!bestPrefix || pattern.length > bestPrefix.pattern.length) {
           bestPrefix = {
             rule,
-            pattern: pat,
-            args: input.length > pat.length ? input.slice(pat.length + 1) : "",
+            pattern,
+            args: input.length > pattern.length ? input.slice(pattern.length + 1) : "",
           };
         }
       }

--- a/src/rules/builtin/build-tools.yaml
+++ b/src/rules/builtin/build-tools.yaml
@@ -93,3 +93,72 @@ rules:
       patterns: ["lein"]
     action: { type: shell, command: "lein", args_passthrough: true }
     safety: write-network
+
+  # ── just ────────────────────────────────────────────────────────────
+  - id: just-info
+    match:
+      type: exact
+      patterns:
+        - "just"
+        - "just --version"
+        - "just --list"
+        - "just -l"
+        - "just --summary"
+        - "just --show"
+        - "just --dump"
+        - "just --fmt --check"
+        - "just --evaluate"
+        - "just --choose"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  - id: just-passthrough
+    match:
+      type: prefix
+      patterns: ["just --list", "just -l", "just --show", "just --summary", "just --dump", "just --evaluate", "just test", "just build", "just run", "just lint", "just fmt"]
+    action: { type: shell, command: "just", args_passthrough: true }
+    safety: write-confined
+
+  # ── task (go-task) ──────────────────────────────────────────────────
+  - id: task-info
+    match:
+      type: exact
+      patterns:
+        - "task --version"
+        - "task --list"
+        - "task -l"
+        - "task --list-all"
+        - "task -a"
+        - "task --summary"
+        - "task"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  - id: task-passthrough
+    match:
+      type: prefix
+      patterns: ["task --list", "task -l", "task --list-all", "task -a", "task --summary", "task --status", "task "]
+    action: { type: shell, command: "task", args_passthrough: true }
+    safety: write-confined
+
+  # ── Meson ───────────────────────────────────────────────────────────
+  - id: meson-info
+    match:
+      type: exact
+      patterns:
+        - "meson --version"
+        - "meson compile"
+        - "meson test"
+        - "meson introspect"
+        - "meson configure"
+        - "meson dist"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-confined
+
+  - id: meson-passthrough
+    match:
+      type: prefix
+      patterns: ["meson setup", "meson compile", "meson test", "meson introspect", "meson configure", "meson install"]
+    action: { type: shell, command: "meson", args_passthrough: true }
+    safety: write-confined
+

--- a/src/rules/builtin/bundlers.yaml
+++ b/src/rules/builtin/bundlers.yaml
@@ -1,0 +1,199 @@
+domain: bundlers
+rules:
+  # ── Vite ────────────────────────────────────────────────────────────
+  - id: vite-common
+    match:
+      type: exact
+      patterns:
+        - "vite"
+        - "vite build"
+        - "vite preview"
+        - "vite dev"
+        - "vite --help"
+        - "vite -h"
+        - "vite --version"
+        - "vite -v"
+        - "vite build --mode production"
+        - "vite build --mode development"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-confined
+
+  - id: vite-passthrough
+    match:
+      type: prefix
+      patterns: ["vite build", "vite preview", "vite dev", "vite --", "vite -"]
+    action: { type: shell, command: "vite", args_passthrough: true }
+    safety: write-confined
+
+  # ── Turbo (Turborepo) ───────────────────────────────────────────────
+  - id: turbo-common
+    match:
+      type: exact
+      patterns:
+        - "turbo build"
+        - "turbo lint"
+        - "turbo test"
+        - "turbo dev"
+        - "turbo run build"
+        - "turbo run lint"
+        - "turbo run test"
+        - "turbo run dev"
+        - "turbo --version"
+        - "turbo -v"
+        - "turbo ls"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-confined
+
+  - id: turbo-passthrough
+    match:
+      type: prefix
+      patterns: ["turbo run", "turbo build", "turbo lint", "turbo test", "turbo dev", "turbo prune"]
+    action: { type: shell, command: "turbo", args_passthrough: true }
+    safety: write-confined
+
+  # ── esbuild ─────────────────────────────────────────────────────────
+  - id: esbuild-info
+    match:
+      type: exact
+      patterns:
+        - "esbuild --version"
+        - "esbuild --help"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  - id: esbuild-passthrough
+    match:
+      type: prefix
+      patterns: ["esbuild"]
+    action: { type: shell, command: "esbuild", args_passthrough: true }
+    safety: write-confined
+
+  # ── SWC ─────────────────────────────────────────────────────────────
+  - id: swc-info
+    match:
+      type: exact
+      patterns:
+        - "swc --version"
+        - "swc --help"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  - id: swc-passthrough
+    match:
+      type: prefix
+      patterns: ["swc "]
+    action: { type: shell, command: "swc", args_passthrough: true }
+    safety: write-confined
+
+  # ── Parcel ──────────────────────────────────────────────────────────
+  - id: parcel-common
+    match:
+      type: exact
+      patterns:
+        - "parcel build"
+        - "parcel serve"
+        - "parcel watch"
+        - "parcel --version"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-confined
+
+  - id: parcel-passthrough
+    match:
+      type: prefix
+      patterns: ["parcel build", "parcel serve", "parcel watch"]
+    action: { type: shell, command: "parcel", args_passthrough: true }
+    safety: write-confined
+
+  # ── Rollup ──────────────────────────────────────────────────────────
+  - id: rollup-info
+    match:
+      type: exact
+      patterns:
+        - "rollup --version"
+        - "rollup -v"
+        - "rollup -c"
+        - "rollup --config"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-confined
+
+  - id: rollup-passthrough
+    match:
+      type: prefix
+      patterns: ["rollup -c", "rollup --config", "rollup -w"]
+    action: { type: shell, command: "rollup", args_passthrough: true }
+    safety: write-confined
+
+  # ── Webpack ─────────────────────────────────────────────────────────
+  - id: webpack-common
+    match:
+      type: exact
+      patterns:
+        - "webpack"
+        - "webpack --version"
+        - "webpack -v"
+        - "webpack build"
+        - "webpack --mode production"
+        - "webpack --mode development"
+        - "webpack serve"
+        - "webpack-cli --version"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-confined
+
+  - id: webpack-passthrough
+    match:
+      type: prefix
+      patterns: ["webpack build", "webpack --mode", "webpack serve", "webpack-dev-server"]
+    action: { type: shell, command: "{{input}}" }
+    safety: write-confined
+
+  # ── Rspack / Rsbuild / Tsup ─────────────────────────────────────────
+  - id: rspack-info
+    match:
+      type: exact
+      patterns:
+        - "rspack --version"
+        - "rspack build"
+        - "rspack dev"
+        - "rsbuild --version"
+        - "rsbuild build"
+        - "rsbuild dev"
+        - "rsbuild preview"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-confined
+
+  - id: tsup-info
+    match:
+      type: exact
+      patterns:
+        - "tsup"
+        - "tsup --version"
+        - "tsup --watch"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-confined
+
+  - id: tsup-passthrough
+    match:
+      type: prefix
+      patterns: ["tsup src", "tsup "]
+    action: { type: shell, command: "tsup", args_passthrough: true }
+    safety: write-confined
+
+  # ── Nx ──────────────────────────────────────────────────────────────
+  - id: nx-info
+    match:
+      type: exact
+      patterns:
+        - "nx --version"
+        - "nx list"
+        - "nx show projects"
+        - "nx graph --file=graph.json"
+        - "nx report"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  - id: nx-passthrough
+    match:
+      type: prefix
+      patterns: ["nx run", "nx build", "nx test", "nx lint", "nx serve", "nx affected", "nx affected:", "nx generate", "nx migrate"]
+    action: { type: shell, command: "nx", args_passthrough: true }
+    safety: write-confined

--- a/src/rules/builtin/cloud.yaml
+++ b/src/rules/builtin/cloud.yaml
@@ -1,0 +1,365 @@
+domain: cloud
+rules:
+  # ── AWS CLI ─────────────────────────────────────────────────────────
+  - id: aws-sts
+    match:
+      type: exact
+      patterns:
+        - "aws sts get-caller-identity"
+        - "aws sts get-session-token"
+        - "aws configure list"
+        - "aws configure list-profiles"
+        - "aws --version"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  - id: aws-s3-ls
+    match:
+      type: prefix
+      patterns: ["aws s3 ls", "aws s3api list-buckets"]
+    action: { type: shell, command: "aws", args_passthrough: true }
+    safety: write-network
+
+  - id: aws-ec2-describe
+    match:
+      type: prefix
+      patterns:
+        - "aws ec2 describe-instances"
+        - "aws ec2 describe-regions"
+        - "aws ec2 describe-vpcs"
+        - "aws ec2 describe-subnets"
+        - "aws ec2 describe-security-groups"
+        - "aws ec2 describe-images"
+        - "aws ec2 describe-volumes"
+    action: { type: shell, command: "aws", args_passthrough: true }
+    safety: write-network
+
+  - id: aws-iam-list
+    match:
+      type: prefix
+      patterns:
+        - "aws iam list-users"
+        - "aws iam list-roles"
+        - "aws iam list-policies"
+        - "aws iam list-groups"
+        - "aws iam get-user"
+    action: { type: shell, command: "aws", args_passthrough: true }
+    safety: write-network
+
+  - id: aws-logs
+    match:
+      type: prefix
+      patterns:
+        - "aws logs describe-log-groups"
+        - "aws logs describe-log-streams"
+        - "aws logs tail"
+    action: { type: shell, command: "aws", args_passthrough: true }
+    safety: write-network
+
+  - id: aws-lambda-list
+    match:
+      type: prefix
+      patterns:
+        - "aws lambda list-functions"
+        - "aws lambda get-function"
+        - "aws lambda list-layers"
+    action: { type: shell, command: "aws", args_passthrough: true }
+    safety: write-network
+
+  - id: aws-cloudformation-list
+    match:
+      type: prefix
+      patterns:
+        - "aws cloudformation list-stacks"
+        - "aws cloudformation describe-stacks"
+        - "aws cloudformation describe-stack-events"
+    action: { type: shell, command: "aws", args_passthrough: true }
+    safety: write-network
+
+  - id: aws-eks
+    match:
+      type: prefix
+      patterns:
+        - "aws eks list-clusters"
+        - "aws eks describe-cluster"
+        - "aws eks list-nodegroups"
+    action: { type: shell, command: "aws", args_passthrough: true }
+    safety: write-network
+
+  - id: aws-rds
+    match:
+      type: prefix
+      patterns:
+        - "aws rds describe-db-instances"
+        - "aws rds describe-db-clusters"
+    action: { type: shell, command: "aws", args_passthrough: true }
+    safety: write-network
+
+  # ── Azure CLI ───────────────────────────────────────────────────────
+  - id: az-account
+    match:
+      type: exact
+      patterns:
+        - "az account show"
+        - "az account list"
+        - "az account list-locations"
+        - "az --version"
+        - "az version"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  - id: az-group-list
+    match:
+      type: prefix
+      patterns:
+        - "az group list"
+        - "az group show"
+    action: { type: shell, command: "az", args_passthrough: true }
+    safety: write-network
+
+  - id: az-vm-list
+    match:
+      type: prefix
+      patterns:
+        - "az vm list"
+        - "az vm show"
+        - "az vm list-ip-addresses"
+        - "az vm list-sizes"
+    action: { type: shell, command: "az", args_passthrough: true }
+    safety: write-network
+
+  - id: az-storage-list
+    match:
+      type: prefix
+      patterns:
+        - "az storage account list"
+        - "az storage blob list"
+        - "az storage container list"
+    action: { type: shell, command: "az", args_passthrough: true }
+    safety: write-network
+
+  - id: az-aks-list
+    match:
+      type: prefix
+      patterns:
+        - "az aks list"
+        - "az aks show"
+        - "az aks get-credentials"
+    action: { type: shell, command: "az", args_passthrough: true }
+    safety: write-network
+
+  # ── Google Cloud ────────────────────────────────────────────────────
+  - id: gcloud-info
+    match:
+      type: exact
+      patterns:
+        - "gcloud auth list"
+        - "gcloud config list"
+        - "gcloud config configurations list"
+        - "gcloud projects list"
+        - "gcloud info"
+        - "gcloud version"
+        - "gcloud --version"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  - id: gcloud-compute
+    match:
+      type: prefix
+      patterns:
+        - "gcloud compute instances list"
+        - "gcloud compute instances describe"
+        - "gcloud compute networks list"
+        - "gcloud compute disks list"
+        - "gcloud compute zones list"
+        - "gcloud compute regions list"
+    action: { type: shell, command: "gcloud", args_passthrough: true }
+    safety: write-network
+
+  - id: gcloud-container
+    match:
+      type: prefix
+      patterns:
+        - "gcloud container clusters list"
+        - "gcloud container clusters describe"
+        - "gcloud container clusters get-credentials"
+        - "gcloud container images list"
+    action: { type: shell, command: "gcloud", args_passthrough: true }
+    safety: write-network
+
+  - id: gcloud-functions
+    match:
+      type: prefix
+      patterns:
+        - "gcloud functions list"
+        - "gcloud functions describe"
+        - "gcloud run services list"
+        - "gcloud run services describe"
+    action: { type: shell, command: "gcloud", args_passthrough: true }
+    safety: write-network
+
+  - id: gsutil-ls
+    match:
+      type: prefix
+      patterns: ["gsutil ls", "gsutil du", "gsutil stat"]
+    action: { type: shell, command: "gsutil", args_passthrough: true }
+    safety: write-network
+
+  # ── Vercel ──────────────────────────────────────────────────────────
+  - id: vercel-info
+    match:
+      type: exact
+      patterns:
+        - "vercel whoami"
+        - "vercel ls"
+        - "vercel list"
+        - "vercel projects ls"
+        - "vercel env ls"
+        - "vercel domains ls"
+        - "vercel teams ls"
+        - "vercel --version"
+        - "vercel -v"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  - id: vercel-logs
+    match:
+      type: prefix
+      patterns: ["vercel logs", "vercel inspect"]
+    action: { type: shell, command: "vercel", args_passthrough: true }
+    safety: write-network
+
+  # ── Netlify ─────────────────────────────────────────────────────────
+  - id: netlify-info
+    match:
+      type: exact
+      patterns:
+        - "netlify status"
+        - "netlify sites:list"
+        - "netlify env:list"
+        - "netlify functions:list"
+        - "netlify --version"
+        - "netlify -v"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  - id: netlify-logs
+    match:
+      type: prefix
+      patterns: ["netlify logs", "netlify deploy --build"]
+    action: { type: shell, command: "netlify", args_passthrough: true }
+    safety: write-network
+
+  # ── Heroku ──────────────────────────────────────────────────────────
+  - id: heroku-info
+    match:
+      type: exact
+      patterns:
+        - "heroku apps"
+        - "heroku apps:info"
+        - "heroku auth:whoami"
+        - "heroku whoami"
+        - "heroku addons"
+        - "heroku releases"
+        - "heroku config"
+        - "heroku ps"
+        - "heroku --version"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  - id: heroku-logs
+    match:
+      type: prefix
+      patterns: ["heroku logs --tail", "heroku logs -t", "heroku logs"]
+    action: { type: shell, command: "heroku logs", args_passthrough: true }
+    safety: write-network
+
+  # ── Fly.io ──────────────────────────────────────────────────────────
+  - id: fly-info
+    match:
+      type: exact
+      patterns:
+        - "fly apps list"
+        - "fly status"
+        - "fly auth whoami"
+        - "fly machines list"
+        - "fly volumes list"
+        - "fly secrets list"
+        - "fly version"
+        - "flyctl apps list"
+        - "flyctl status"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  - id: fly-logs
+    match:
+      type: prefix
+      patterns: ["fly logs", "flyctl logs"]
+    action: { type: shell, command: "{{input}}" }
+    safety: write-network
+
+  # ── Railway ─────────────────────────────────────────────────────────
+  - id: railway-info
+    match:
+      type: exact
+      patterns:
+        - "railway status"
+        - "railway whoami"
+        - "railway variables"
+        - "railway logs"
+        - "railway --version"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  # ── Render / Supabase / DigitalOcean ────────────────────────────────
+  - id: render-info
+    match:
+      type: exact
+      patterns: ["render services", "render --version"]
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  - id: supabase-info
+    match:
+      type: exact
+      patterns:
+        - "supabase projects list"
+        - "supabase status"
+        - "supabase functions list"
+        - "supabase --version"
+        - "supabase -v"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  - id: doctl-info
+    match:
+      type: prefix
+      patterns:
+        - "doctl auth list"
+        - "doctl compute droplet list"
+        - "doctl kubernetes cluster list"
+        - "doctl account get"
+        - "doctl databases list"
+        - "doctl apps list"
+    action: { type: shell, command: "doctl", args_passthrough: true }
+    safety: write-network
+
+  # ── Natural-language shortcuts ──────────────────────────────────────
+  - id: nl-aws-identity
+    match:
+      type: nl
+      keywords:
+        - ["aws", "identity"]
+        - ["who", "am", "i", "aws"]
+        - ["current", "aws", "account"]
+    action: { type: shell, command: "aws sts get-caller-identity" }
+    safety: write-network
+
+  - id: nl-gcloud-project
+    match:
+      type: nl
+      keywords:
+        - ["current", "gcloud", "project"]
+        - ["active", "gcloud", "project"]
+    action: { type: shell, command: "gcloud config list --format=value(core.project)" }
+    safety: write-network

--- a/src/rules/builtin/dart-flutter.yaml
+++ b/src/rules/builtin/dart-flutter.yaml
@@ -1,0 +1,75 @@
+domain: dart-flutter
+rules:
+  # ── Dart ────────────────────────────────────────────────────────────
+  - id: dart-info
+    match:
+      type: exact
+      patterns:
+        - "dart --version"
+        - "dart --help"
+        - "dart pub get"
+        - "dart pub upgrade"
+        - "dart pub outdated"
+        - "dart pub deps"
+        - "dart pub downgrade"
+        - "dart analyze"
+        - "dart format ."
+        - "dart format --set-exit-if-changed ."
+        - "dart test"
+        - "dart fix --dry-run"
+        - "dart compile exe"
+        - "dart doc"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  - id: dart-passthrough
+    match:
+      type: prefix
+      patterns:
+        - "dart run"
+        - "dart test"
+        - "dart analyze"
+        - "dart format"
+        - "dart pub"
+        - "dart compile"
+        - "dart fix"
+    action: { type: shell, command: "dart", args_passthrough: true }
+    safety: write-network
+
+  # ── Flutter ─────────────────────────────────────────────────────────
+  - id: flutter-info
+    match:
+      type: exact
+      patterns:
+        - "flutter --version"
+        - "flutter -v"
+        - "flutter doctor"
+        - "flutter doctor -v"
+        - "flutter devices"
+        - "flutter emulators"
+        - "flutter channel"
+        - "flutter config"
+        - "flutter pub get"
+        - "flutter pub upgrade"
+        - "flutter pub outdated"
+        - "flutter pub deps"
+        - "flutter clean"
+        - "flutter analyze"
+        - "flutter test"
+        - "flutter test --coverage"
+        - "flutter precache"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  - id: flutter-passthrough
+    match:
+      type: prefix
+      patterns:
+        - "flutter run"
+        - "flutter build"
+        - "flutter test"
+        - "flutter analyze"
+        - "flutter pub"
+        - "flutter create"
+    action: { type: shell, command: "flutter", args_passthrough: true }
+    safety: write-network

--- a/src/rules/builtin/database-extra.yaml
+++ b/src/rules/builtin/database-extra.yaml
@@ -1,0 +1,175 @@
+domain: database-extra
+rules:
+  # ── PostgreSQL tooling ──────────────────────────────────────────────
+  - id: pg-info
+    match:
+      type: exact
+      patterns:
+        - "pg_isready"
+        - "pg_config --version"
+        - "pg_config"
+        - "pg_lsclusters"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  - id: pg-isready-passthrough
+    match:
+      type: prefix
+      patterns: ["pg_isready -h", "pg_isready -p", "pg_isready -U"]
+    action: { type: shell, command: "pg_isready", args_passthrough: true }
+    safety: read-only
+
+  # ── MongoDB (Atlas CLI) ─────────────────────────────────────────────
+  - id: atlas-info
+    match:
+      type: exact
+      patterns:
+        - "atlas --version"
+        - "atlas auth whoami"
+        - "atlas projects list"
+        - "atlas clusters list"
+        - "atlas clusters describe"
+        - "atlas dbusers list"
+        - "atlas networking peering list"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  # ── CockroachDB ─────────────────────────────────────────────────────
+  - id: cockroach-info
+    match:
+      type: exact
+      patterns:
+        - "cockroach version"
+        - "cockroach --version"
+        - "cockroach node status"
+        - "cockroach node ls"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  # ── ClickHouse ──────────────────────────────────────────────────────
+  - id: clickhouse-info
+    match:
+      type: exact
+      patterns:
+        - "clickhouse-client --version"
+        - "clickhouse --version"
+        - "clickhouse server --version"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  # ── InfluxDB ────────────────────────────────────────────────────────
+  - id: influx-info
+    match:
+      type: exact
+      patterns:
+        - "influx version"
+        - "influx --version"
+        - "influx bucket list"
+        - "influx org list"
+        - "influx config list"
+        - "influx ping"
+        - "influxd version"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  # ── Cassandra (cqlsh) ───────────────────────────────────────────────
+  - id: cassandra-info
+    match:
+      type: exact
+      patterns:
+        - "cqlsh --version"
+        - "cqlsh -e \"DESCRIBE KEYSPACES\""
+        - "cqlsh -e 'DESCRIBE KEYSPACES'"
+        - "nodetool status"
+        - "nodetool info"
+        - "nodetool version"
+        - "nodetool ring"
+        - "nodetool describecluster"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  # ── DynamoDB local / scripts ────────────────────────────────────────
+  - id: dynamodb-list
+    match:
+      type: exact
+      patterns:
+        - "aws dynamodb list-tables"
+        - "aws dynamodb describe-limits"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  - id: dynamodb-describe
+    match:
+      type: prefix
+      patterns:
+        - "aws dynamodb describe-table"
+        - "aws dynamodb scan"
+        - "aws dynamodb query"
+    action: { type: shell, command: "aws", args_passthrough: true }
+    safety: write-network
+
+  # ── DuckDB ──────────────────────────────────────────────────────────
+  - id: duckdb-info
+    match:
+      type: exact
+      patterns:
+        - "duckdb --version"
+        - "duckdb -version"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  # ── Prisma / Drizzle / Sequelize / TypeORM migrations ───────────────
+  - id: prisma-info
+    match:
+      type: exact
+      patterns:
+        - "prisma --version"
+        - "prisma -v"
+        - "prisma generate"
+        - "prisma validate"
+        - "prisma format"
+        - "prisma db pull"
+        - "prisma migrate status"
+        - "prisma migrate diff"
+        - "npx prisma --version"
+        - "npx prisma generate"
+        - "npx prisma validate"
+        - "npx prisma format"
+        - "npx prisma migrate status"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  - id: drizzle-info
+    match:
+      type: exact
+      patterns:
+        - "drizzle-kit --version"
+        - "drizzle-kit check"
+        - "drizzle-kit generate"
+        - "drizzle-kit introspect"
+        - "drizzle-kit studio"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  # ── Sequelize / Knex / TypeORM CLI ──────────────────────────────────
+  - id: sequelize-info
+    match:
+      type: exact
+      patterns:
+        - "sequelize --version"
+        - "sequelize db:migrate:status"
+        - "sequelize-cli --version"
+        - "sequelize-cli db:migrate:status"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  - id: knex-info
+    match:
+      type: exact
+      patterns:
+        - "knex --version"
+        - "knex migrate:list"
+        - "knex migrate:status"
+        - "knex migrate:currentVersion"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network

--- a/src/rules/builtin/deno.yaml
+++ b/src/rules/builtin/deno.yaml
@@ -1,0 +1,44 @@
+domain: deno
+rules:
+  - id: deno-info
+    match:
+      type: exact
+      patterns:
+        - "deno --version"
+        - "deno -V"
+        - "deno info"
+        - "deno upgrade --dry-run"
+        - "deno task"
+        - "deno coverage"
+        - "deno bench"
+        - "deno doc"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  - id: deno-check
+    match:
+      type: exact
+      patterns:
+        - "deno check"
+        - "deno fmt"
+        - "deno fmt --check"
+        - "deno lint"
+        - "deno test"
+        - "deno test --allow-all"
+        - "deno test --coverage"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  - id: deno-run-passthrough
+    match:
+      type: prefix
+      patterns: ["deno run", "deno task", "deno test", "deno bench", "deno doc", "deno info", "deno fmt", "deno lint", "deno check", "deno compile", "deno install"]
+    action: { type: shell, command: "deno", args_passthrough: true }
+    safety: write-network
+
+  - id: deno-cache
+    match:
+      type: prefix
+      patterns: ["deno cache"]
+    action: { type: shell, command: "deno cache", args_passthrough: true }
+    safety: write-network

--- a/src/rules/builtin/distributed.yaml
+++ b/src/rules/builtin/distributed.yaml
@@ -1,0 +1,105 @@
+domain: distributed
+rules:
+  # ── Consul ──────────────────────────────────────────────────────────
+  - id: consul-info
+    match:
+      type: exact
+      patterns:
+        - "consul version"
+        - "consul --version"
+        - "consul members"
+        - "consul operator raft list-peers"
+        - "consul catalog nodes"
+        - "consul catalog services"
+        - "consul catalog datacenters"
+        - "consul info"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  - id: consul-kv
+    match:
+      type: prefix
+      patterns: ["consul kv get", "consul kv list", "consul catalog", "consul services", "consul acl", "consul snapshot inspect"]
+    action: { type: shell, command: "consul", args_passthrough: true }
+    safety: write-network
+
+  # ── etcd / etcdctl ──────────────────────────────────────────────────
+  - id: etcd-info
+    match:
+      type: exact
+      patterns:
+        - "etcdctl version"
+        - "etcdctl --version"
+        - "etcdctl endpoint status"
+        - "etcdctl endpoint health"
+        - "etcdctl member list"
+        - "etcd --version"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  - id: etcd-get
+    match:
+      type: prefix
+      patterns: ["etcdctl get", "etcdctl get --prefix", "etcdctl endpoint", "etcdctl member", "etcdctl lease list", "etcdctl alarm list"]
+    action: { type: shell, command: "etcdctl", args_passthrough: true }
+    safety: write-network
+
+  # ── Zookeeper (via zkCli) ───────────────────────────────────────────
+  - id: zookeeper-info
+    match:
+      type: exact
+      patterns:
+        - "zkCli.sh"
+        - "zkServer.sh status"
+        - "zkServer.sh version"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  # ── NATS ────────────────────────────────────────────────────────────
+  - id: nats-info
+    match:
+      type: exact
+      patterns:
+        - "nats --version"
+        - "nats server check"
+        - "nats server ls"
+        - "nats server report connz"
+        - "nats server report jsz"
+        - "nats account info"
+        - "nats stream ls"
+        - "nats consumer ls"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  # ── Kafka (kcat / kafka-topics.sh) ──────────────────────────────────
+  - id: kafka-info
+    match:
+      type: exact
+      patterns:
+        - "kafka-topics.sh --list"
+        - "kafka-consumer-groups.sh --list"
+        - "kafka-configs.sh --describe"
+        - "kcat -L"
+        - "kcat -V"
+        - "kcat -h"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  # ── RabbitMQ ────────────────────────────────────────────────────────
+  - id: rabbitmqctl-info
+    match:
+      type: exact
+      patterns:
+        - "rabbitmqctl status"
+        - "rabbitmqctl cluster_status"
+        - "rabbitmqctl list_queues"
+        - "rabbitmqctl list_exchanges"
+        - "rabbitmqctl list_bindings"
+        - "rabbitmqctl list_connections"
+        - "rabbitmqctl list_consumers"
+        - "rabbitmqctl list_vhosts"
+        - "rabbitmqctl list_users"
+        - "rabbitmqctl environment"
+        - "rabbitmqctl version"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network

--- a/src/rules/builtin/elixir.yaml
+++ b/src/rules/builtin/elixir.yaml
@@ -1,0 +1,77 @@
+domain: elixir
+rules:
+  - id: mix-info
+    match:
+      type: exact
+      patterns:
+        - "mix --version"
+        - "mix help"
+        - "mix deps"
+        - "mix deps.tree"
+        - "mix deps.get"
+        - "mix deps.update --all"
+        - "mix deps.clean --unused"
+        - "mix compile"
+        - "mix test"
+        - "mix test --cover"
+        - "mix test --trace"
+        - "mix format"
+        - "mix format --check-formatted"
+        - "mix credo"
+        - "mix credo --strict"
+        - "mix dialyzer"
+        - "mix docs"
+        - "mix ecto.migrate"
+        - "mix ecto.rollback"
+        - "mix ecto.gen.migration"
+        - "mix phx.server"
+        - "mix phx.routes"
+        - "mix release"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-confined
+
+  - id: mix-passthrough
+    match:
+      type: prefix
+      patterns: ["mix test", "mix compile", "mix format", "mix credo", "mix ecto", "mix phx", "mix run", "mix deps", "mix do", "mix help"]
+    action: { type: shell, command: "mix", args_passthrough: true }
+    safety: write-confined
+
+  - id: elixir-info
+    match:
+      type: exact
+      patterns:
+        - "elixir --version"
+        - "elixir -v"
+        - "iex --version"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  - id: elixir-passthrough
+    match:
+      type: prefix
+      patterns: ["elixir "]
+    action: { type: shell, command: "elixir", args_passthrough: true }
+    safety: write-confined
+
+  - id: iex-interactive
+    match:
+      type: exact
+      patterns: ["iex", "iex -S mix", "iex -S mix phx.server"]
+    action:
+      type: passthrough
+      reason: "iex is an interactive REPL"
+    safety: read-only
+
+  - id: erlang-info
+    match:
+      type: exact
+      patterns:
+        - "erl -version"
+        - "erlc --version"
+        - "rebar3 --version"
+        - "rebar3 compile"
+        - "rebar3 eunit"
+        - "rebar3 ct"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-confined

--- a/src/rules/builtin/env-mgmt.yaml
+++ b/src/rules/builtin/env-mgmt.yaml
@@ -1,0 +1,207 @@
+domain: env-mgmt
+rules:
+  # ── direnv ──────────────────────────────────────────────────────────
+  - id: direnv-info
+    match:
+      type: exact
+      patterns:
+        - "direnv status"
+        - "direnv version"
+        - "direnv --version"
+        - "direnv show_dump"
+        - "direnv allow"
+        - "direnv deny"
+        - "direnv reload"
+        - "direnv edit"
+        - "direnv prune"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-confined
+
+  # ── asdf ────────────────────────────────────────────────────────────
+  - id: asdf-info
+    match:
+      type: exact
+      patterns:
+        - "asdf --version"
+        - "asdf current"
+        - "asdf list"
+        - "asdf plugin list"
+        - "asdf plugin list all"
+        - "asdf plugin-list"
+        - "asdf latest --all"
+        - "asdf where"
+        - "asdf which"
+        - "asdf info"
+        - "asdf doctor"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  - id: asdf-passthrough
+    match:
+      type: prefix
+      patterns: ["asdf current", "asdf list", "asdf plugin list", "asdf where", "asdf which", "asdf latest", "asdf install", "asdf uninstall", "asdf global", "asdf local", "asdf shell"]
+    action: { type: shell, command: "asdf", args_passthrough: true }
+    safety: write-confined
+
+  # ── mise (aka rtx) ──────────────────────────────────────────────────
+  - id: mise-info
+    match:
+      type: exact
+      patterns:
+        - "mise --version"
+        - "mise -v"
+        - "mise version"
+        - "mise ls"
+        - "mise list"
+        - "mise current"
+        - "mise ls-remote"
+        - "mise env"
+        - "mise doctor"
+        - "mise plugin ls"
+        - "mise plugin list"
+        - "mise settings"
+        - "mise where"
+        - "mise which"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  - id: mise-passthrough
+    match:
+      type: prefix
+      patterns: ["mise ls", "mise list", "mise install", "mise uninstall", "mise use", "mise exec", "mise run", "mise tasks", "mise upgrade", "mise plugin"]
+    action: { type: shell, command: "mise", args_passthrough: true }
+    safety: write-network
+
+  # ── nvm (only read-ish) ─────────────────────────────────────────────
+  - id: nvm-info
+    match:
+      type: exact
+      patterns:
+        - "nvm --version"
+        - "nvm current"
+        - "nvm ls"
+        - "nvm list"
+        - "nvm which"
+        - "nvm version"
+        - "nvm deactivate"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  # ── pyenv / rbenv / jenv ────────────────────────────────────────────
+  - id: pyenv-info
+    match:
+      type: exact
+      patterns:
+        - "pyenv --version"
+        - "pyenv version"
+        - "pyenv versions"
+        - "pyenv which python"
+        - "pyenv which pip"
+        - "pyenv which python3"
+        - "pyenv local"
+        - "pyenv global"
+        - "pyenv shell"
+        - "pyenv doctor"
+        - "pyenv rehash"
+        - "pyenv commands"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  - id: pyenv-passthrough
+    match:
+      type: prefix
+      patterns: ["pyenv install", "pyenv uninstall", "pyenv virtualenv", "pyenv activate", "pyenv deactivate", "pyenv local", "pyenv global", "pyenv shell"]
+    action: { type: shell, command: "pyenv", args_passthrough: true }
+    safety: write-network
+
+  - id: rbenv-info
+    match:
+      type: exact
+      patterns:
+        - "rbenv --version"
+        - "rbenv version"
+        - "rbenv versions"
+        - "rbenv which ruby"
+        - "rbenv local"
+        - "rbenv global"
+        - "rbenv shell"
+        - "rbenv doctor"
+        - "rbenv rehash"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  - id: jenv-info
+    match:
+      type: exact
+      patterns:
+        - "jenv --version"
+        - "jenv version"
+        - "jenv versions"
+        - "jenv doctor"
+        - "jenv which java"
+        - "jenv commands"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  # ── Nix ─────────────────────────────────────────────────────────────
+  - id: nix-info
+    match:
+      type: exact
+      patterns:
+        - "nix --version"
+        - "nix-env --version"
+        - "nix doctor"
+        - "nix show-config"
+        - "nix flake metadata"
+        - "nix flake show"
+        - "nix flake check"
+        - "nix flake lock"
+        - "nix-channel --list"
+        - "nix-channel --update"
+        - "nix-store --version"
+        - "nix-env -q"
+        - "nix-env --query"
+        - "nix-env -qa"
+        - "nix-shell --version"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  - id: nix-passthrough
+    match:
+      type: prefix
+      patterns: ["nix flake", "nix build", "nix develop", "nix search", "nix run", "nix profile list", "nix store gc", "nix-env -q", "nix-env --query"]
+    action: { type: shell, command: "nix", args_passthrough: true }
+    safety: write-network
+
+  # ── SDKMAN ──────────────────────────────────────────────────────────
+  - id: sdk-info
+    match:
+      type: exact
+      patterns:
+        - "sdk version"
+        - "sdk current"
+        - "sdk list"
+        - "sdk ls"
+        - "sdk offline"
+        - "sdk help"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  # ── mamba (conda core lives in python.yaml) ─────────────────────────
+  - id: mamba-info
+    match:
+      type: exact
+      patterns:
+        - "mamba --version"
+        - "mamba info"
+        - "mamba env list"
+        - "mamba list"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  - id: mamba-passthrough
+    match:
+      type: prefix
+      patterns: ["mamba create", "mamba install", "mamba update", "mamba env create", "mamba env update", "mamba env remove"]
+    action: { type: shell, command: "mamba", args_passthrough: true }
+    safety: write-network

--- a/src/rules/builtin/iac.yaml
+++ b/src/rules/builtin/iac.yaml
@@ -1,0 +1,217 @@
+domain: iac
+rules:
+  # ── Terraform ───────────────────────────────────────────────────────
+  - id: terraform-info
+    match:
+      type: exact
+      patterns:
+        - "terraform version"
+        - "terraform --version"
+        - "terraform -v"
+        - "terraform workspace list"
+        - "terraform workspace show"
+        - "terraform providers"
+        - "terraform fmt"
+        - "terraform fmt -check"
+        - "terraform fmt -recursive"
+        - "terraform validate"
+        - "terraform show"
+        - "terraform output"
+        - "terraform output -json"
+        - "terraform state list"
+        - "terraform state pull"
+        - "terraform init"
+        - "terraform init -upgrade"
+        - "terraform init -reconfigure"
+        - "terraform plan"
+        - "terraform plan -out=tfplan"
+        - "terraform graph"
+        - "terraform refresh"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  - id: terraform-passthrough
+    match:
+      type: prefix
+      patterns:
+        - "terraform plan"
+        - "terraform fmt"
+        - "terraform validate"
+        - "terraform show"
+        - "terraform output"
+        - "terraform state list"
+        - "terraform state show"
+        - "terraform workspace"
+        - "terraform providers"
+        - "terraform init"
+        - "terraform console"
+    action: { type: shell, command: "terraform", args_passthrough: true }
+    safety: write-network
+
+  # ── tofu (OpenTofu) ─────────────────────────────────────────────────
+  - id: tofu-info
+    match:
+      type: exact
+      patterns:
+        - "tofu version"
+        - "tofu --version"
+        - "tofu workspace list"
+        - "tofu fmt -check"
+        - "tofu validate"
+        - "tofu plan"
+        - "tofu init"
+        - "tofu providers"
+        - "tofu output"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  # ── Ansible ─────────────────────────────────────────────────────────
+  - id: ansible-info
+    match:
+      type: exact
+      patterns:
+        - "ansible --version"
+        - "ansible-playbook --version"
+        - "ansible-galaxy --version"
+        - "ansible-lint --version"
+        - "ansible-inventory --list"
+        - "ansible-inventory --graph"
+        - "ansible-config list"
+        - "ansible-config dump"
+        - "ansible-doc -l"
+        - "ansible-vault --version"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  - id: ansible-playbook-check
+    match:
+      type: prefix
+      patterns:
+        - "ansible-playbook --syntax-check"
+        - "ansible-playbook --check"
+        - "ansible-playbook --list-hosts"
+        - "ansible-playbook --list-tasks"
+        - "ansible-playbook --list-tags"
+    action: { type: shell, command: "ansible-playbook", args_passthrough: true }
+    safety: read-only
+
+  - id: ansible-galaxy-list
+    match:
+      type: prefix
+      patterns:
+        - "ansible-galaxy list"
+        - "ansible-galaxy collection list"
+        - "ansible-galaxy role list"
+    action: { type: shell, command: "ansible-galaxy", args_passthrough: true }
+    safety: read-only
+
+  - id: ansible-inventory-passthrough
+    match:
+      type: prefix
+      patterns: ["ansible-inventory"]
+    action: { type: shell, command: "ansible-inventory", args_passthrough: true }
+    safety: read-only
+
+  - id: ansible-lint
+    match:
+      type: prefix
+      patterns: ["ansible-lint"]
+    action: { type: shell, command: "ansible-lint", args_passthrough: true }
+    safety: read-only
+
+  # ── Vagrant ─────────────────────────────────────────────────────────
+  - id: vagrant-info
+    match:
+      type: exact
+      patterns:
+        - "vagrant status"
+        - "vagrant global-status"
+        - "vagrant version"
+        - "vagrant --version"
+        - "vagrant box list"
+        - "vagrant plugin list"
+        - "vagrant validate"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  - id: vagrant-lifecycle
+    match:
+      type: prefix
+      patterns:
+        - "vagrant up"
+        - "vagrant halt"
+        - "vagrant reload"
+        - "vagrant suspend"
+        - "vagrant resume"
+        - "vagrant provision"
+    action: { type: shell, command: "{{input}}" }
+    safety: write-network
+
+  # ── Pulumi ──────────────────────────────────────────────────────────
+  - id: pulumi-info
+    match:
+      type: exact
+      patterns:
+        - "pulumi version"
+        - "pulumi whoami"
+        - "pulumi stack ls"
+        - "pulumi stack"
+        - "pulumi preview"
+        - "pulumi config"
+        - "pulumi plugin ls"
+        - "pulumi logout"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  - id: pulumi-preview
+    match:
+      type: prefix
+      patterns: ["pulumi preview", "pulumi stack", "pulumi config", "pulumi logs", "pulumi plugin ls"]
+    action: { type: shell, command: "pulumi", args_passthrough: true }
+    safety: write-network
+
+  # ── Packer ──────────────────────────────────────────────────────────
+  - id: packer-info
+    match:
+      type: exact
+      patterns:
+        - "packer version"
+        - "packer --version"
+        - "packer fmt -check"
+        - "packer validate"
+        - "packer inspect"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  - id: packer-passthrough
+    match:
+      type: prefix
+      patterns: ["packer validate", "packer fmt", "packer inspect"]
+    action: { type: shell, command: "packer", args_passthrough: true }
+    safety: read-only
+
+  # ── CDK ─────────────────────────────────────────────────────────────
+  - id: cdk-info
+    match:
+      type: exact
+      patterns:
+        - "cdk --version"
+        - "cdk list"
+        - "cdk ls"
+        - "cdk doctor"
+        - "cdk synth"
+        - "cdk diff"
+        - "cdktf --version"
+        - "cdktf list"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  # ── Natural-language shortcuts ──────────────────────────────────────
+  - id: nl-terraform-plan
+    match:
+      type: nl
+      keywords:
+        - ["terraform", "plan"]
+        - ["tf", "plan"]
+    action: { type: shell, command: "terraform plan" }
+    safety: write-network

--- a/src/rules/builtin/java.yaml
+++ b/src/rules/builtin/java.yaml
@@ -100,3 +100,27 @@ rules:
       patterns: ["./gradlew"]
     action: { type: shell, command: "./gradlew", args_passthrough: true }
     safety: write-network
+
+  - id: mvnw-common
+    match:
+      type: exact
+      patterns:
+        - "./mvnw --version"
+        - "./mvnw -v"
+        - "./mvnw compile"
+        - "./mvnw test"
+        - "./mvnw package"
+        - "./mvnw verify"
+        - "./mvnw clean"
+        - "./mvnw clean install"
+        - "./mvnw clean package"
+        - "./mvnw dependency:tree"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  - id: mvnw-passthrough
+    match:
+      type: prefix
+      patterns: ["./mvnw"]
+    action: { type: shell, command: "./mvnw", args_passthrough: true }
+    safety: write-network

--- a/src/rules/builtin/linters.yaml
+++ b/src/rules/builtin/linters.yaml
@@ -83,3 +83,103 @@ rules:
       patterns: ["markdownlint"]
     action: { type: shell, command: "markdownlint", args_passthrough: true }
     safety: write-confined
+
+  # ── Biome ───────────────────────────────────────────────────────────
+  - id: biome-info
+    match:
+      type: exact
+      patterns:
+        - "biome --version"
+        - "biome -V"
+        - "biome check"
+        - "biome check ."
+        - "biome check --write"
+        - "biome check --write ."
+        - "biome lint"
+        - "biome lint ."
+        - "biome format"
+        - "biome format --write"
+        - "biome format --write ."
+        - "biome ci"
+        - "biome ci ."
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-confined
+
+  - id: biome-passthrough
+    match:
+      type: prefix
+      patterns: ["biome check", "biome lint", "biome format", "biome ci", "biome migrate", "biome explain"]
+    action: { type: shell, command: "biome", args_passthrough: true }
+    safety: write-confined
+
+  # ── oxlint ──────────────────────────────────────────────────────────
+  - id: oxlint
+    match:
+      type: prefix
+      patterns: ["oxlint --fix", "oxlint"]
+    action: { type: shell, command: "oxlint", args_passthrough: true }
+    safety: write-confined
+
+  # ── dprint ──────────────────────────────────────────────────────────
+  - id: dprint-info
+    match:
+      type: exact
+      patterns:
+        - "dprint --version"
+        - "dprint check"
+        - "dprint fmt"
+        - "dprint fmt --check"
+        - "dprint output-file-paths"
+        - "dprint output-format-times"
+        - "dprint config dump"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-confined
+
+  - id: dprint-passthrough
+    match:
+      type: prefix
+      patterns: ["dprint check", "dprint fmt", "dprint output-file-paths", "dprint output-format-times"]
+    action: { type: shell, command: "dprint", args_passthrough: true }
+    safety: write-confined
+
+  # ── actionlint / jsonlint / gitleaks / pre-commit ───────────────────
+  - id: actionlint
+    match:
+      type: prefix
+      patterns: ["actionlint"]
+    action: { type: shell, command: "actionlint", args_passthrough: true }
+    safety: read-only
+
+  - id: jsonlint
+    match:
+      type: prefix
+      patterns: ["jsonlint"]
+    action: { type: shell, command: "jsonlint", args_passthrough: true }
+    safety: read-only
+
+  - id: gitleaks
+    match:
+      type: prefix
+      patterns: ["gitleaks detect", "gitleaks protect", "gitleaks version"]
+    action: { type: shell, command: "gitleaks", args_passthrough: true }
+    safety: read-only
+
+  - id: pre-commit-info
+    match:
+      type: exact
+      patterns:
+        - "pre-commit --version"
+        - "pre-commit run --all-files"
+        - "pre-commit run"
+        - "pre-commit install"
+        - "pre-commit autoupdate"
+        - "pre-commit clean"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-confined
+
+  - id: pre-commit-passthrough
+    match:
+      type: prefix
+      patterns: ["pre-commit run", "pre-commit install", "pre-commit autoupdate", "pre-commit try-repo", "pre-commit migrate-config"]
+    action: { type: shell, command: "pre-commit", args_passthrough: true }
+    safety: write-confined

--- a/src/rules/builtin/process-supervisors.yaml
+++ b/src/rules/builtin/process-supervisors.yaml
@@ -1,0 +1,146 @@
+domain: process-supervisors
+rules:
+  # ── pm2 ─────────────────────────────────────────────────────────────
+  - id: pm2-info
+    match:
+      type: exact
+      patterns:
+        - "pm2 list"
+        - "pm2 ls"
+        - "pm2 status"
+        - "pm2 jlist"
+        - "pm2 monit"
+        - "pm2 info"
+        - "pm2 show"
+        - "pm2 env"
+        - "pm2 --version"
+        - "pm2 -v"
+        - "pm2 prettylist"
+        - "pm2 dump"
+        - "pm2 describe"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  - id: pm2-logs
+    match:
+      type: prefix
+      patterns: ["pm2 logs", "pm2 flush"]
+    action: { type: shell, command: "pm2", args_passthrough: true }
+    safety: read-only
+
+  - id: pm2-lifecycle
+    match:
+      type: prefix
+      patterns:
+        - "pm2 start"
+        - "pm2 stop"
+        - "pm2 restart"
+        - "pm2 reload"
+        - "pm2 delete"
+        - "pm2 scale"
+        - "pm2 save"
+        - "pm2 resurrect"
+    action: { type: shell, command: "pm2", args_passthrough: true }
+    safety: write-confined
+
+  # ── systemctl --user (rootless) ─────────────────────────────────────
+  - id: systemctl-user-info
+    match:
+      type: exact
+      patterns:
+        - "systemctl --user list-units"
+        - "systemctl --user list-unit-files"
+        - "systemctl --user list-timers"
+        - "systemctl --user list-sockets"
+        - "systemctl --user --failed"
+        - "systemctl --user daemon-reload"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  - id: systemctl-user-passthrough
+    match:
+      type: prefix
+      patterns:
+        - "systemctl --user status"
+        - "systemctl --user is-active"
+        - "systemctl --user is-enabled"
+        - "systemctl --user cat"
+        - "systemctl --user show"
+        - "systemctl --user list-units"
+        - "systemctl --user list-unit-files"
+    action: { type: shell, command: "systemctl --user", args_passthrough: true }
+    safety: read-only
+
+  - id: systemctl-status-rootless
+    match:
+      type: prefix
+      patterns:
+        - "systemctl status"
+        - "systemctl is-active"
+        - "systemctl is-enabled"
+        - "systemctl is-failed"
+        - "systemctl list-units"
+        - "systemctl list-unit-files"
+        - "systemctl list-timers"
+        - "systemctl cat"
+        - "systemctl show"
+        - "systemctl --failed"
+        - "systemctl --version"
+    action: { type: shell, command: "systemctl", args_passthrough: true }
+    safety: read-only
+
+  - id: journalctl-read
+    match:
+      type: prefix
+      patterns:
+        - "journalctl --user"
+        - "journalctl -u"
+        - "journalctl --since"
+        - "journalctl --boot"
+        - "journalctl -xe"
+        - "journalctl -f"
+    action: { type: shell, command: "journalctl", args_passthrough: true }
+    safety: read-only
+
+  - id: launchctl-info
+    match:
+      type: exact
+      patterns:
+        - "launchctl list"
+        - "launchctl print gui"
+        - "launchctl print user"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  # ── foreman / overmind ──────────────────────────────────────────────
+  - id: foreman-info
+    match:
+      type: exact
+      patterns:
+        - "foreman version"
+        - "foreman check"
+        - "foreman start"
+        - "overmind --version"
+        - "overmind ps"
+        - "overmind status"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  - id: overmind-passthrough
+    match:
+      type: prefix
+      patterns: ["overmind start", "overmind restart", "overmind stop", "overmind connect"]
+    action: { type: shell, command: "overmind", args_passthrough: true }
+    safety: write-confined
+
+  # ── supervisord ─────────────────────────────────────────────────────
+  - id: supervisorctl-info
+    match:
+      type: exact
+      patterns:
+        - "supervisorctl status"
+        - "supervisorctl pid"
+        - "supervisorctl version"
+        - "supervisorctl avail"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only

--- a/src/rules/builtin/python.yaml
+++ b/src/rules/builtin/python.yaml
@@ -271,3 +271,131 @@ rules:
       patterns: ["flake8"]
     action: { type: shell, command: "flake8", args_passthrough: true }
     safety: read-only
+
+  # ── pdm ─────────────────────────────────────────────────────────────
+  - id: pdm-info
+    match:
+      type: exact
+      patterns:
+        - "pdm --version"
+        - "pdm -V"
+        - "pdm info"
+        - "pdm config"
+        - "pdm list"
+        - "pdm list --tree"
+        - "pdm show"
+        - "pdm lock"
+        - "pdm install"
+        - "pdm sync"
+        - "pdm build"
+        - "pdm outdated"
+        - "pdm self list"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  - id: pdm-passthrough
+    match:
+      type: prefix
+      patterns: ["pdm install", "pdm sync", "pdm add", "pdm remove", "pdm update", "pdm run", "pdm lock", "pdm show", "pdm list", "pdm build", "pdm outdated"]
+    action: { type: shell, command: "pdm", args_passthrough: true }
+    safety: write-network
+
+  # ── hatch ───────────────────────────────────────────────────────────
+  - id: hatch-info
+    match:
+      type: exact
+      patterns:
+        - "hatch --version"
+        - "hatch -V"
+        - "hatch env show"
+        - "hatch config show"
+        - "hatch project metadata"
+        - "hatch version"
+        - "hatch status"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  - id: hatch-passthrough
+    match:
+      type: prefix
+      patterns: ["hatch run", "hatch env", "hatch build", "hatch publish", "hatch test", "hatch version", "hatch dep"]
+    action: { type: shell, command: "hatch", args_passthrough: true }
+    safety: write-network
+
+  # ── pipenv ──────────────────────────────────────────────────────────
+  - id: pipenv-info
+    match:
+      type: exact
+      patterns:
+        - "pipenv --version"
+        - "pipenv --venv"
+        - "pipenv --py"
+        - "pipenv --where"
+        - "pipenv graph"
+        - "pipenv check"
+        - "pipenv lock --clear"
+        - "pipenv lock"
+        - "pipenv requirements"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: write-network
+
+  - id: pipenv-passthrough
+    match:
+      type: prefix
+      patterns: ["pipenv install", "pipenv uninstall", "pipenv run", "pipenv shell", "pipenv lock", "pipenv update", "pipenv clean"]
+    action: { type: shell, command: "pipenv", args_passthrough: true }
+    safety: write-network
+
+  # ── pipx ────────────────────────────────────────────────────────────
+  - id: pipx-info
+    match:
+      type: exact
+      patterns:
+        - "pipx --version"
+        - "pipx list"
+        - "pipx list --short"
+        - "pipx environment"
+        - "pipx ensurepath"
+        - "pipx completions"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  - id: pipx-passthrough
+    match:
+      type: prefix
+      patterns: ["pipx install", "pipx uninstall", "pipx upgrade", "pipx run", "pipx inject", "pipx runpip", "pipx reinstall"]
+    action: { type: shell, command: "pipx", args_passthrough: true }
+    safety: write-network
+
+  # ── Type checkers / tools ───────────────────────────────────────────
+  - id: pyright-info
+    match:
+      type: exact
+      patterns:
+        - "pyright --version"
+        - "pyright --help"
+        - "pyright"
+        - "pyright --outputjson"
+    action: { type: shell, command: "{{input}}", args_passthrough: false }
+    safety: read-only
+
+  - id: pyright-passthrough
+    match:
+      type: prefix
+      patterns: ["pyright"]
+    action: { type: shell, command: "pyright", args_passthrough: true }
+    safety: read-only
+
+  - id: bandit
+    match:
+      type: prefix
+      patterns: ["bandit -r", "bandit"]
+    action: { type: shell, command: "bandit", args_passthrough: true }
+    safety: read-only
+
+  - id: pyupgrade
+    match:
+      type: prefix
+      patterns: ["pyupgrade"]
+    action: { type: shell, command: "pyupgrade", args_passthrough: true }
+    safety: write-confined

--- a/src/rules/loader.ts
+++ b/src/rules/loader.ts
@@ -3,7 +3,7 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
-import type { LoadedRules, Rule, RuleFile } from "./types.js";
+import type { LoadedRules, PrefixEntry, Rule, RuleFile } from "./types.js";
 import { classify } from "../router/classifier.js";
 import { logger } from "../utils/logger.js";
 
@@ -75,6 +75,7 @@ export async function loadRules(): Promise<LoadedRules> {
   const byDomain = new Map<string, Rule[]>();
   const exactIndex = new Map<string, Rule>();
   const prefixRules: Rule[] = [];
+  const prefixByFirstWord = new Map<string, PrefixEntry[]>();
   const regexRules: Rule[] = [];
   const nlRules: Rule[] = [];
 
@@ -92,6 +93,15 @@ export async function loadRules(): Promise<LoadedRules> {
         break;
       case "prefix":
         prefixRules.push(r);
+        for (const p of r.match.patterns) {
+          const norm = p.trim().replace(/\s+/g, " ");
+          if (!norm) continue;
+          const space = norm.indexOf(" ");
+          const head = space === -1 ? norm : norm.slice(0, space);
+          const bucket = prefixByFirstWord.get(head) ?? [];
+          bucket.push({ rule: r, pattern: norm });
+          prefixByFirstWord.set(head, bucket);
+        }
         break;
       case "regex":
         regexRules.push(r);
@@ -102,7 +112,15 @@ export async function loadRules(): Promise<LoadedRules> {
     }
   }
 
-  cache = { rules, byDomain, exactIndex, prefixRules, regexRules, nlRules };
+  cache = {
+    rules,
+    byDomain,
+    exactIndex,
+    prefixRules,
+    prefixByFirstWord,
+    regexRules,
+    nlRules,
+  };
   return cache;
 }
 

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -42,11 +42,17 @@ export interface RuleFile {
   rules: Rule[];
 }
 
+export interface PrefixEntry {
+  rule: Rule;
+  pattern: string;
+}
+
 export interface LoadedRules {
   rules: Rule[];
   byDomain: Map<string, Rule[]>;
   exactIndex: Map<string, Rule>;
   prefixRules: Rule[];
+  prefixByFirstWord: Map<string, PrefixEntry[]>;
   regexRules: Rule[];
   nlRules: Rule[];
 }

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -5,6 +5,8 @@ import { configDir, configPath, loadConfig, saveConfig, DEFAULT_CONFIG } from ".
 import type { Config } from "../config/user-config.js";
 import { detectShell, installBlock, uninstallBlock, rcFileFor } from "./shell-install.js";
 import type { ShellName } from "./shell-install.js";
+import { installMcp, uninstallMcp } from "./mcp-install.js";
+import type { McpInstallResult } from "./mcp-install.js";
 import { logger } from "../utils/logger.js";
 
 export interface SetupOpts {
@@ -16,6 +18,8 @@ export interface SetupOpts {
   quiet?: boolean;
   /** Don't write anything; just report what would change. */
   dryRun?: boolean;
+  /** Skip auto-registering `ninja mcp` with Claude Code / Cursor / Claude Desktop. */
+  noMcp?: boolean;
 }
 
 function normalizeShell(s: string | undefined): ShellName {
@@ -78,11 +82,25 @@ export async function runSetup(opts: SetupOpts = {}): Promise<number> {
       ].join("\n")
     );
     process.stdout.write(block + "\n");
+    if (!opts.noMcp) {
+      const mcp = await installMcp({ dryRun: true });
+      for (const r of mcp) {
+        if (r.changed) {
+          process.stdout.write(
+            `[dry-run] would register MCP for ${r.target.label} at ${r.target.path}${r.created ? " (create)" : ""}\n`
+          );
+        } else if (r.skippedReason) {
+          process.stdout.write(`[dry-run] skip MCP for ${r.target.label}: ${r.skippedReason}\n`);
+        }
+      }
+    }
     return 0;
   }
 
   const result = await installBlock(block, shell);
   await ensureConfig(hooked[0]);
+
+  const mcpResults: McpInstallResult[] = opts.noMcp ? [] : await installMcp();
 
   if (!opts.quiet) {
     const lines = [
@@ -94,6 +112,20 @@ export async function runSetup(opts: SetupOpts = {}): Promise<number> {
     ];
     if (result.backupPath) lines.push(`  backup      : ${result.backupPath}`);
     if (!result.changed) lines.push(`  (already installed — no changes)`);
+
+    if (!opts.noMcp) {
+      const registered = mcpResults.filter((r) => r.changed).map((r) => r.target.label);
+      const skipped = mcpResults.filter((r) => r.skippedReason);
+      if (registered.length > 0) {
+        lines.push(`  mcp         : registered ninja mcp with ${registered.join(", ")}`);
+      } else {
+        lines.push(`  mcp         : already registered (or no MCP clients detected)`);
+      }
+      for (const s of skipped) {
+        lines.push(`  mcp warning : ${s.target.label}: ${s.skippedReason}`);
+      }
+    }
+
     lines.push(``);
     lines.push(`Open a new terminal (or: source ${result.rcFile}) and use your AI tool normally.`);
     lines.push(`Commands token-ninja recognizes run locally; everything else passes through.`);
@@ -107,12 +139,17 @@ export async function runSetup(opts: SetupOpts = {}): Promise<number> {
 export async function runUninstall(opts: { shell?: string; quiet?: boolean } = {}): Promise<number> {
   const shell = normalizeShell(opts.shell);
   const result = await uninstallBlock(shell);
+  const mcp = await uninstallMcp();
   if (!opts.quiet) {
     if (result.changed) {
       process.stdout.write(`token-ninja: removed managed block from ${result.rcFile}\n`);
       process.stdout.write(`Open a new terminal (or: source ${result.rcFile}) to restore original AI tool behavior.\n`);
     } else {
       process.stdout.write(`token-ninja: no managed block found in ${result.rcFile}\n`);
+    }
+    const unregistered = mcp.filter((r) => r.changed).map((r) => r.target.label);
+    if (unregistered.length > 0) {
+      process.stdout.write(`token-ninja: removed MCP entry from ${unregistered.join(", ")}\n`);
     }
   }
   return 0;

--- a/src/setup/mcp-install.ts
+++ b/src/setup/mcp-install.ts
@@ -1,0 +1,275 @@
+import { readFile, writeFile, access, mkdir, copyFile, rename } from "node:fs/promises";
+import { homedir, platform } from "node:os";
+import { dirname, join } from "node:path";
+
+/**
+ * Zero-config MCP registration. Writes `token-ninja` into each MCP-capable
+ * client's config file so interactive agent sessions (Claude Code REPL,
+ * Cursor, Claude Desktop) consult `ninja mcp` automatically. We merge rather
+ * than replace: every other key in the target file is preserved, we back it
+ * up once before the first modification, and we skip writes when our entry
+ * is already present with the same command.
+ */
+
+export const TOKEN_NINJA_KEY = "token-ninja";
+
+export interface McpClientTarget {
+  /** Stable id used in logs and dry-run output. */
+  id: "claude-code" | "cursor" | "claude-desktop";
+  /** Human-readable label. */
+  label: string;
+  /** Path to the config file we'd write. */
+  path: string;
+  /** Which top-level key in the file holds the server map. */
+  serversKey: string;
+}
+
+export interface McpInstallResult {
+  target: McpClientTarget;
+  changed: boolean;
+  created: boolean;
+  skippedReason?: string;
+  backupPath: string | null;
+}
+
+export interface McpServerEntry {
+  command: string;
+  args?: string[];
+}
+
+export const MCP_SERVER_ENTRY: McpServerEntry = {
+  command: "ninja",
+  args: ["mcp"],
+};
+
+export function mcpTargets(
+  env: NodeJS.ProcessEnv = process.env,
+  home: string = homedir(),
+  os: NodeJS.Platform = platform()
+): McpClientTarget[] {
+  const out: McpClientTarget[] = [];
+
+  // Claude Code — user-scoped config. The file is created on first `claude`
+  // run; if it doesn't exist yet we create it rather than skip, so a fresh
+  // install works on the user's first REPL session.
+  out.push({
+    id: "claude-code",
+    label: "Claude Code",
+    path: env.CLAUDE_CONFIG_PATH ?? join(home, ".claude.json"),
+    serversKey: "mcpServers",
+  });
+
+  // Cursor — per-user MCP config.
+  out.push({
+    id: "cursor",
+    label: "Cursor",
+    path: join(home, ".cursor", "mcp.json"),
+    serversKey: "mcpServers",
+  });
+
+  // Claude Desktop — OS-specific.
+  let desktopPath: string | null = null;
+  if (os === "darwin") {
+    desktopPath = join(home, "Library", "Application Support", "Claude", "claude_desktop_config.json");
+  } else if (os === "win32") {
+    const appdata = env.APPDATA ?? join(home, "AppData", "Roaming");
+    desktopPath = join(appdata, "Claude", "claude_desktop_config.json");
+  } else {
+    const xdg = env.XDG_CONFIG_HOME ?? join(home, ".config");
+    desktopPath = join(xdg, "Claude", "claude_desktop_config.json");
+  }
+  out.push({
+    id: "claude-desktop",
+    label: "Claude Desktop",
+    path: desktopPath,
+    serversKey: "mcpServers",
+  });
+
+  return out;
+}
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Merge a `token-ninja` server entry into the parsed config. Returns the new
+ * object (always a fresh copy) and a flag indicating whether anything
+ * changed. Non-object inputs produce a new object; non-object `mcpServers`
+ * is replaced with a fresh map to avoid corrupting the file.
+ */
+export function mergeMcpEntry(
+  existing: unknown,
+  serversKey: string,
+  entry: McpServerEntry = MCP_SERVER_ENTRY
+): { next: Record<string, unknown>; changed: boolean } {
+  const base: Record<string, unknown> =
+    existing && typeof existing === "object" && !Array.isArray(existing)
+      ? { ...(existing as Record<string, unknown>) }
+      : {};
+
+  const currentServers = base[serversKey];
+  const servers: Record<string, unknown> =
+    currentServers && typeof currentServers === "object" && !Array.isArray(currentServers)
+      ? { ...(currentServers as Record<string, unknown>) }
+      : {};
+
+  const prev = servers[TOKEN_NINJA_KEY];
+  const prevMatches =
+    prev !== undefined &&
+    typeof prev === "object" &&
+    prev !== null &&
+    (prev as Record<string, unknown>).command === entry.command &&
+    JSON.stringify((prev as Record<string, unknown>).args ?? []) ===
+      JSON.stringify(entry.args ?? []);
+
+  if (prevMatches) {
+    return { next: base, changed: false };
+  }
+
+  servers[TOKEN_NINJA_KEY] = { ...entry };
+  base[serversKey] = servers;
+  return { next: base, changed: true };
+}
+
+/**
+ * Strip our entry out of the parsed config. Leaves other servers intact.
+ */
+export function removeMcpEntry(
+  existing: unknown,
+  serversKey: string
+): { next: Record<string, unknown>; changed: boolean } {
+  if (!existing || typeof existing !== "object" || Array.isArray(existing)) {
+    return { next: {}, changed: false };
+  }
+  const base = { ...(existing as Record<string, unknown>) };
+  const currentServers = base[serversKey];
+  if (!currentServers || typeof currentServers !== "object" || Array.isArray(currentServers)) {
+    return { next: base, changed: false };
+  }
+  const servers = { ...(currentServers as Record<string, unknown>) };
+  if (!(TOKEN_NINJA_KEY in servers)) {
+    return { next: base, changed: false };
+  }
+  delete servers[TOKEN_NINJA_KEY];
+  base[serversKey] = servers;
+  return { next: base, changed: true };
+}
+
+async function writeAtomic(path: string, content: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.token-ninja.tmp`;
+  await writeFile(tmp, content, "utf8");
+  await rename(tmp, path);
+}
+
+export interface InstallMcpOpts {
+  dryRun?: boolean;
+  targets?: McpClientTarget[];
+}
+
+export async function installMcp(opts: InstallMcpOpts = {}): Promise<McpInstallResult[]> {
+  const targets = opts.targets ?? mcpTargets();
+  const results: McpInstallResult[] = [];
+
+  for (const target of targets) {
+    const existed = await fileExists(target.path);
+    let parsed: unknown = null;
+    if (existed) {
+      try {
+        const raw = await readFile(target.path, "utf8");
+        parsed = raw.trim() === "" ? {} : JSON.parse(raw);
+      } catch (err) {
+        results.push({
+          target,
+          changed: false,
+          created: false,
+          backupPath: null,
+          skippedReason: `could not parse ${target.path}: ${(err as Error).message}`,
+        });
+        continue;
+      }
+    }
+
+    const { next, changed } = mergeMcpEntry(parsed ?? {}, target.serversKey);
+    if (!changed) {
+      results.push({ target, changed: false, created: false, backupPath: null });
+      continue;
+    }
+
+    if (opts.dryRun) {
+      results.push({ target, changed: true, created: !existed, backupPath: null });
+      continue;
+    }
+
+    let backupPath: string | null = null;
+    if (existed) {
+      const candidate = `${target.path}.token-ninja.bak`;
+      if (!(await fileExists(candidate))) {
+        backupPath = candidate;
+        try {
+          await copyFile(target.path, candidate);
+        } catch {
+          backupPath = null;
+        }
+      }
+    }
+
+    try {
+      await writeAtomic(target.path, JSON.stringify(next, null, 2) + "\n");
+    } catch (err) {
+      results.push({
+        target,
+        changed: false,
+        created: false,
+        backupPath,
+        skippedReason: `could not write ${target.path}: ${(err as Error).message}`,
+      });
+      continue;
+    }
+
+    results.push({ target, changed: true, created: !existed, backupPath });
+  }
+
+  return results;
+}
+
+export async function uninstallMcp(opts: { targets?: McpClientTarget[] } = {}): Promise<
+  Array<{ target: McpClientTarget; changed: boolean }>
+> {
+  const targets = opts.targets ?? mcpTargets();
+  const results: Array<{ target: McpClientTarget; changed: boolean }> = [];
+
+  for (const target of targets) {
+    if (!(await fileExists(target.path))) {
+      results.push({ target, changed: false });
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      const raw = await readFile(target.path, "utf8");
+      parsed = raw.trim() === "" ? {} : JSON.parse(raw);
+    } catch {
+      results.push({ target, changed: false });
+      continue;
+    }
+    const { next, changed } = removeMcpEntry(parsed, target.serversKey);
+    if (!changed) {
+      results.push({ target, changed: false });
+      continue;
+    }
+    try {
+      await writeAtomic(target.path, JSON.stringify(next, null, 2) + "\n");
+      results.push({ target, changed: true });
+    } catch {
+      results.push({ target, changed: false });
+    }
+  }
+
+  return results;
+}

--- a/tests/fixtures/real-commands.txt
+++ b/tests/fixtures/real-commands.txt
@@ -437,3 +437,283 @@ show running containers
 list images
 show pods
 list services
+
+# ── cloud CLIs ────────────────────────────────────────────────────────
+aws sts get-caller-identity
+aws s3 ls
+aws ec2 describe-instances
+aws iam list-users
+aws lambda list-functions
+aws logs describe-log-groups
+aws eks list-clusters
+aws rds describe-db-instances
+aws cloudformation list-stacks
+aws --version
+az account show
+az group list
+az vm list
+az aks list
+az --version
+gcloud auth list
+gcloud config list
+gcloud projects list
+gcloud compute instances list
+gcloud container clusters list
+gcloud version
+gsutil ls gs://my-bucket
+vercel ls
+vercel logs my-project
+vercel whoami
+netlify status
+netlify sites:list
+heroku apps
+heroku logs --tail
+heroku ps
+fly status
+fly apps list
+flyctl status
+railway status
+supabase status
+doctl compute droplet list
+
+# ── IaC ───────────────────────────────────────────────────────────────
+terraform plan
+terraform init
+terraform fmt -check
+terraform validate
+terraform workspace list
+terraform output -json
+terraform state list
+terraform providers
+terraform version
+tofu plan
+tofu validate
+ansible --version
+ansible-playbook --syntax-check site.yml
+ansible-inventory --list
+ansible-galaxy list
+ansible-lint
+vagrant status
+vagrant global-status
+vagrant box list
+pulumi preview
+pulumi stack ls
+pulumi whoami
+packer validate template.json
+cdk synth
+cdk diff
+cdk ls
+
+# ── bundlers ──────────────────────────────────────────────────────────
+vite build
+vite preview
+vite --version
+turbo build
+turbo run test
+turbo --version
+esbuild --version
+parcel build src/index.html
+parcel --version
+rollup -c
+webpack --mode production
+webpack serve
+rspack build
+rsbuild build
+tsup src/index.ts
+nx list
+nx run myapp:build
+nx affected --target=test
+
+# ── Deno ──────────────────────────────────────────────────────────────
+deno --version
+deno info
+deno test
+deno fmt --check
+deno lint
+deno check
+deno task build
+deno run --allow-net script.ts
+
+# ── Elixir / Erlang ───────────────────────────────────────────────────
+mix --version
+mix deps.get
+mix test
+mix compile
+mix format --check-formatted
+mix credo
+mix phx.server
+mix phx.routes
+mix ecto.migrate
+elixir --version
+rebar3 compile
+rebar3 eunit
+
+# ── Dart / Flutter ────────────────────────────────────────────────────
+dart --version
+dart pub get
+dart analyze
+dart format .
+dart test
+flutter --version
+flutter doctor
+flutter doctor -v
+flutter devices
+flutter pub get
+flutter clean
+flutter analyze
+flutter test
+flutter build apk
+flutter run
+
+# ── process supervisors ───────────────────────────────────────────────
+pm2 list
+pm2 status
+pm2 logs
+pm2 start ecosystem.config.js
+pm2 restart all
+systemctl --user list-units
+systemctl --user status myapp
+systemctl status nginx
+systemctl list-timers
+journalctl --user -u myapp
+journalctl -u nginx
+launchctl list
+overmind ps
+overmind start
+foreman start
+supervisorctl status
+
+# ── env management ────────────────────────────────────────────────────
+direnv status
+direnv allow
+asdf current
+asdf list
+asdf plugin list
+asdf install nodejs 20.11.0
+mise ls
+mise current
+mise install node@20
+mise use python@3.12
+mise env
+nvm current
+nvm ls
+pyenv versions
+pyenv which python
+rbenv versions
+jenv versions
+nix --version
+nix flake show
+nix flake check
+nix-env -q
+nix-channel --list
+sdk current
+sdk list
+conda info --envs
+conda list
+conda env list
+mamba list
+
+# ── distributed systems ───────────────────────────────────────────────
+consul version
+consul members
+consul catalog services
+consul kv get foo
+etcdctl version
+etcdctl endpoint status
+etcdctl endpoint health
+etcdctl member list
+etcdctl get /config/foo
+zkServer.sh status
+nats --version
+nats server check
+nats stream ls
+kafka-topics.sh --list
+kcat -L
+rabbitmqctl status
+rabbitmqctl list_queues
+
+# ── database extras ───────────────────────────────────────────────────
+pg_isready
+pg_isready -h localhost -p 5432
+pg_config --version
+atlas --version
+atlas clusters list
+atlas auth whoami
+cockroach version
+cockroach node status
+clickhouse-client --version
+influx version
+influx bucket list
+cqlsh --version
+nodetool status
+nodetool info
+aws dynamodb list-tables
+aws dynamodb describe-table --table-name users
+duckdb --version
+prisma --version
+prisma generate
+prisma migrate status
+npx prisma generate
+drizzle-kit check
+drizzle-kit generate
+sequelize-cli db:migrate:status
+knex migrate:list
+
+# ── python extras ─────────────────────────────────────────────────────
+pdm --version
+pdm install
+pdm lock
+pdm add requests
+pdm list --tree
+hatch --version
+hatch env show
+hatch run test
+pipenv --version
+pipenv graph
+pipenv install
+pipx list
+pipx install black
+pipx install ruff
+pyright --version
+pyright src
+pylint src
+bandit -r src
+
+# ── build-tools extras ────────────────────────────────────────────────
+just --list
+just --summary
+just test
+task --list
+task -l
+task build
+meson --version
+meson compile
+meson test
+gradle --version
+gradle tasks
+./gradlew build
+./gradlew test
+mvn --version
+mvn clean package
+mvn test
+mvn dependency:tree
+./mvnw test
+
+# ── modern linters ────────────────────────────────────────────────────
+biome --version
+biome check .
+biome check --write .
+biome lint .
+biome format --write .
+biome ci .
+oxlint src
+dprint check
+dprint fmt
+dprint --version
+actionlint .github/workflows/ci.yml
+jsonlint package.json
+gitleaks detect
+gitleaks version
+pre-commit --version
+pre-commit run --all-files
+pre-commit install

--- a/tests/mcp-install.test.ts
+++ b/tests/mcp-install.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtemp, readFile, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  MCP_SERVER_ENTRY,
+  TOKEN_NINJA_KEY,
+  installMcp,
+  mergeMcpEntry,
+  removeMcpEntry,
+  uninstallMcp,
+} from "../src/setup/mcp-install.js";
+import type { McpClientTarget } from "../src/setup/mcp-install.js";
+
+describe("mergeMcpEntry", () => {
+  it("adds a token-ninja entry into an empty config", () => {
+    const { next, changed } = mergeMcpEntry({}, "mcpServers");
+    expect(changed).toBe(true);
+    const servers = next.mcpServers as Record<string, unknown>;
+    expect(servers[TOKEN_NINJA_KEY]).toEqual(MCP_SERVER_ENTRY);
+  });
+
+  it("preserves other top-level keys and other MCP servers", () => {
+    const existing = {
+      editor: { theme: "dark" },
+      mcpServers: {
+        "my-other-server": { command: "node", args: ["srv.js"] },
+      },
+    };
+    const { next, changed } = mergeMcpEntry(existing, "mcpServers");
+    expect(changed).toBe(true);
+    expect((next as typeof existing).editor).toEqual({ theme: "dark" });
+    const servers = next.mcpServers as Record<string, unknown>;
+    expect(servers["my-other-server"]).toEqual({ command: "node", args: ["srv.js"] });
+    expect(servers[TOKEN_NINJA_KEY]).toEqual(MCP_SERVER_ENTRY);
+  });
+
+  it("is idempotent when the same entry already exists", () => {
+    const first = mergeMcpEntry({}, "mcpServers");
+    const second = mergeMcpEntry(first.next, "mcpServers");
+    expect(second.changed).toBe(false);
+  });
+
+  it("updates the entry if the command drifted", () => {
+    const stale = {
+      mcpServers: {
+        [TOKEN_NINJA_KEY]: { command: "some-old-bin", args: ["mcp"] },
+      },
+    };
+    const { next, changed } = mergeMcpEntry(stale, "mcpServers");
+    expect(changed).toBe(true);
+    const servers = next.mcpServers as Record<string, unknown>;
+    expect(servers[TOKEN_NINJA_KEY]).toEqual(MCP_SERVER_ENTRY);
+  });
+
+  it("rebuilds mcpServers when the existing value has the wrong shape", () => {
+    const broken = { mcpServers: "not-an-object" };
+    const { next, changed } = mergeMcpEntry(broken, "mcpServers");
+    expect(changed).toBe(true);
+    const servers = next.mcpServers as Record<string, unknown>;
+    expect(servers[TOKEN_NINJA_KEY]).toEqual(MCP_SERVER_ENTRY);
+  });
+
+  it("treats non-object input as an empty config", () => {
+    const { next, changed } = mergeMcpEntry(null, "mcpServers");
+    expect(changed).toBe(true);
+    expect(next.mcpServers).toBeDefined();
+  });
+});
+
+describe("removeMcpEntry", () => {
+  it("removes our entry and leaves others intact", () => {
+    const existing = {
+      mcpServers: {
+        [TOKEN_NINJA_KEY]: { command: "ninja", args: ["mcp"] },
+        other: { command: "node" },
+      },
+    };
+    const { next, changed } = removeMcpEntry(existing, "mcpServers");
+    expect(changed).toBe(true);
+    const servers = next.mcpServers as Record<string, unknown>;
+    expect(servers[TOKEN_NINJA_KEY]).toBeUndefined();
+    expect(servers.other).toEqual({ command: "node" });
+  });
+
+  it("is a no-op when the entry is absent", () => {
+    const { changed } = removeMcpEntry({ mcpServers: {} }, "mcpServers");
+    expect(changed).toBe(false);
+  });
+});
+
+describe("installMcp", () => {
+  let dir = "";
+  let target: McpClientTarget;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "tn-mcp-"));
+    target = {
+      id: "claude-code",
+      label: "Claude Code (test)",
+      path: join(dir, ".claude.json"),
+      serversKey: "mcpServers",
+    };
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("creates the config file when it doesn't exist", async () => {
+    const results = await installMcp({ targets: [target] });
+    expect(results[0]!.changed).toBe(true);
+    expect(results[0]!.created).toBe(true);
+    const raw = await readFile(target.path, "utf8");
+    const parsed = JSON.parse(raw);
+    expect(parsed.mcpServers[TOKEN_NINJA_KEY]).toEqual(MCP_SERVER_ENTRY);
+  });
+
+  it("preserves unrelated keys in an existing file", async () => {
+    await writeFile(
+      target.path,
+      JSON.stringify({ theme: "dark", mcpServers: { other: { command: "x" } } }, null, 2),
+      "utf8"
+    );
+    const results = await installMcp({ targets: [target] });
+    expect(results[0]!.changed).toBe(true);
+    const parsed = JSON.parse(await readFile(target.path, "utf8"));
+    expect(parsed.theme).toBe("dark");
+    expect(parsed.mcpServers.other).toEqual({ command: "x" });
+    expect(parsed.mcpServers[TOKEN_NINJA_KEY]).toEqual(MCP_SERVER_ENTRY);
+  });
+
+  it("is idempotent across repeated runs and backs up only once", async () => {
+    await writeFile(target.path, JSON.stringify({ mcpServers: {} }), "utf8");
+    const first = await installMcp({ targets: [target] });
+    expect(first[0]!.changed).toBe(true);
+    expect(first[0]!.backupPath).toBe(`${target.path}.token-ninja.bak`);
+    const second = await installMcp({ targets: [target] });
+    expect(second[0]!.changed).toBe(false);
+    expect(second[0]!.backupPath).toBeNull();
+  });
+
+  it("skips safely when the file is malformed", async () => {
+    await writeFile(target.path, "{not json", "utf8");
+    const results = await installMcp({ targets: [target] });
+    expect(results[0]!.changed).toBe(false);
+    expect(results[0]!.skippedReason).toMatch(/could not parse/);
+    // File is untouched
+    expect(await readFile(target.path, "utf8")).toBe("{not json");
+  });
+
+  it("dry-run does not write but reports intended change", async () => {
+    const results = await installMcp({ targets: [target], dryRun: true });
+    expect(results[0]!.changed).toBe(true);
+    await expect(readFile(target.path, "utf8")).rejects.toBeTruthy();
+  });
+
+  it("creates parent directories when needed", async () => {
+    const nested = {
+      ...target,
+      path: join(dir, "does", "not", "exist", ".claude.json"),
+    };
+    const results = await installMcp({ targets: [nested] });
+    expect(results[0]!.changed).toBe(true);
+    const parsed = JSON.parse(await readFile(nested.path, "utf8"));
+    expect(parsed.mcpServers[TOKEN_NINJA_KEY]).toEqual(MCP_SERVER_ENTRY);
+  });
+});
+
+describe("uninstallMcp", () => {
+  let dir = "";
+  let target: McpClientTarget;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "tn-mcp-u-"));
+    target = {
+      id: "claude-code",
+      label: "Claude Code (test)",
+      path: join(dir, ".claude.json"),
+      serversKey: "mcpServers",
+    };
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("is a no-op when the config file is missing", async () => {
+    const results = await uninstallMcp({ targets: [target] });
+    expect(results[0]!.changed).toBe(false);
+  });
+
+  it("removes the token-ninja entry but keeps the file and other servers", async () => {
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      target.path,
+      JSON.stringify({
+        mcpServers: {
+          [TOKEN_NINJA_KEY]: { command: "ninja", args: ["mcp"] },
+          other: { command: "node" },
+        },
+      }),
+      "utf8"
+    );
+    const results = await uninstallMcp({ targets: [target] });
+    expect(results[0]!.changed).toBe(true);
+    const parsed = JSON.parse(await readFile(target.path, "utf8"));
+    expect(parsed.mcpServers[TOKEN_NINJA_KEY]).toBeUndefined();
+    expect(parsed.mcpServers.other).toEqual({ command: "node" });
+  });
+});


### PR DESCRIPTION
Add ~160 rules across cloud (AWS/Azure/gcloud/Vercel/Netlify/Heroku/Fly/
Railway/doctl/Supabase), IaC (Terraform/Ansible/Vagrant/Pulumi/Packer/CDK),
modern bundlers (Vite/Turbo/esbuild/Parcel/Rollup/Webpack/Rspack/tsup/Nx),
Deno, Elixir/Mix, Dart/Flutter, process supervisors (pm2/systemctl --user/
journalctl/overmind/foreman), env managers (direnv/asdf/mise/pyenv/rbenv/
nix/sdkman/mamba), distributed systems (consul/etcd/zookeeper/NATS/Kafka/
RabbitMQ), plus extras for Python (pdm/hatch/pipenv/pipx/pyright), build
tools (just/task/meson/mvnw), databases (cqlsh/cockroach/clickhouse/influx/
dynamodb/duckdb/prisma/drizzle/knex/sequelize/atlas), and modern linters
(biome/oxlint/dprint/actionlint/gitleaks/pre-commit).

Total rules: 472 → 631. Fixture hit-rate: 85% floor → 100% (657 commands).

Perf: prefix matching was O(N·M) over rule patterns, which regressed to
139µs/call with the added rules. Bucket prefix candidates by their first
whitespace-delimited token in the loader; classify() now scans only the
bucket matching the input's first token. Result: 19µs/call — better than
the 37µs baseline despite 33% more rules.

README: distinguish one-shot shell invocations (`claude -p "git status"`)
from interactive REPL sessions (`claude` with no args). The shell shim only
wraps one-shot calls; interactive sessions must register `ninja mcp` as an
MCP server. Added an `.mcp.json` snippet under the MCP integration section.