### PR TITLE
feat(setup): intercept Claude Code Bash tool via PreToolUse hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ it can find on your machine — Claude Code (`~/.claude.json`), Cursor
 AI tool, it already knows to consult token-ninja before spending tokens on
 commands like `git status`, `npm test`, or `docker ps`.
 
+For **Claude Code** specifically, the same postinstall also writes a
+`PreToolUse` Bash hook into `~/.claude/settings.json`. Claude Code's built-in
+`Bash` tool normally runs shell commands unconditionally; the hook intercepts
+each call, passes the command through `ninja route`, and — if a local rule
+matched — blocks the Bash call and returns the captured output back to
+Claude. Without the hook, Claude would ignore the MCP server in favor of
+Bash; with it, deterministic commands never reach the model. Skip with
+`ninja setup --no-hook`.
+
 Existing MCP entries are preserved, each file is backed up once
 (`*.token-ninja.bak`) before the first write, and malformed configs are
 skipped safely instead of failing the install.
@@ -117,7 +126,8 @@ skipped safely instead of failing the install.
 > `TOKEN_NINJA_SKIP_POSTINSTALL=1 npm install -g token-ninja`
 >
 > **Roll back any time:** `ninja uninstall` — removes the MCP entry from
-> every client config it wrote to.
+> every client config it wrote to, and the Bash hook from
+> `~/.claude/settings.json`.
 
 ## Quickstart
 
@@ -317,10 +327,46 @@ Use `ninja rules test "your command"` to dry-run the classifier against any inpu
 
 ## MCP integration
 
-token-ninja talks to your AI tool through the Model Context Protocol: it
+token-ninja talks to most AI tools through the Model Context Protocol: it
 exposes a single stdio tool (`maybe_execute_locally`) that the agent calls
 on every command it's about to run. If token-ninja recognizes the command,
 it answers with the output directly; if not, the agent proceeds as usual.
+
+### Claude Code: MCP + PreToolUse Bash hook
+
+Claude Code's built-in `Bash` tool is separate from its MCP tool list, and
+the model has no default instruction to consult MCP tools before running
+shell commands. The MCP server alone therefore won't save tokens on `git
+status`-class calls. To close that gap, `ninja setup` also installs a
+`PreToolUse` Bash hook at `~/.claude/settings.json`:
+
+```jsonc
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "node /abs/path/to/hooks/claude-code-bash.cjs" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+On every Bash call, the hook runs `ninja route --cwd <cwd> <command>`. On a
+match it returns `{decision:"block", reason:"..."}` with the captured output
+in the reason — Claude reads that output and answers the user without the
+Bash tool ever executing. On a miss (or any unexpected error) the hook
+exits 0 and Bash proceeds normally, so token-ninja is never a single point
+of failure for the shell.
+
+Install control:
+
+- `ninja setup --no-hook` — skip just the Bash hook (MCP still registered).
+- `ninja setup --no-mcp` — skip just MCP (hook still installed).
+- `ninja uninstall` — removes both, plus any shell-rc shims.
 
 **You don't need to configure this manually.** `ninja setup` (the postinstall
 hook) merges an entry like the one below into:

--- a/hooks/claude-code-bash.cjs
+++ b/hooks/claude-code-bash.cjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/*
+ * token-ninja — Claude Code PreToolUse hook for Bash.
+ *
+ * Claude Code sends us a JSON payload on stdin. For Bash calls, we ask the
+ * `ninja` CLI whether it can handle the command locally. If yes, we block
+ * Bash and return the output as the decision reason — Claude reads it and
+ * answers the user without ever spending tokens on execution. If not, we
+ * exit 0 and Bash proceeds as usual.
+ *
+ * Fail-open: any unexpected condition (ninja missing, parse failure, timeout)
+ * exits 0. We never turn token-ninja into a single point of failure for the
+ * user's shell.
+ */
+
+const { spawnSync } = require("node:child_process");
+
+const HOOK_TIMEOUT_MS = 15000;
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let buf = "";
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      resolve(buf);
+    };
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => {
+      buf += chunk;
+    });
+    process.stdin.on("end", finish);
+    process.stdin.on("error", finish);
+    // Safety net: if Claude never closes stdin for some reason, don't hang.
+    setTimeout(finish, HOOK_TIMEOUT_MS).unref();
+  });
+}
+
+function safeParse(raw) {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function passthrough() {
+  process.exit(0);
+}
+
+function buildReason(result) {
+  const parts = [];
+  const rule = result.rule_id || "local";
+  const saved = Number(result.tokens_saved_estimate || 0);
+  parts.push(
+    `[token-ninja handled locally — rule:${rule}, saved ~${saved.toLocaleString("en-US")} tokens]`
+  );
+  parts.push(`exit_code: ${typeof result.exit_code === "number" ? result.exit_code : 0}`);
+  if (result.stdout && result.stdout.length > 0) {
+    parts.push("stdout:");
+    parts.push(result.stdout.replace(/\n+$/, ""));
+  }
+  if (result.stderr && result.stderr.length > 0) {
+    parts.push("stderr:");
+    parts.push(result.stderr.replace(/\n+$/, ""));
+  }
+  parts.push(
+    "The Bash call was intercepted; the command has already executed locally. Use this output to answer the user directly — do not re-run the command via Bash."
+  );
+  return parts.join("\n");
+}
+
+async function main() {
+  const raw = await readStdin();
+  const input = safeParse(raw);
+  if (!input || input.tool_name !== "Bash") passthrough();
+
+  const command =
+    input && input.tool_input && typeof input.tool_input.command === "string"
+      ? input.tool_input.command
+      : "";
+  if (!command.trim()) passthrough();
+
+  const cwd = (input && input.cwd && typeof input.cwd === "string") ? input.cwd : process.cwd();
+
+  let spawned;
+  try {
+    spawned = spawnSync("ninja", ["route", "--cwd", cwd, command], {
+      encoding: "utf8",
+      timeout: HOOK_TIMEOUT_MS,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+  } catch {
+    passthrough();
+  }
+  if (!spawned || spawned.error || spawned.status !== 0) passthrough();
+
+  const stdout = (spawned.stdout || "").trim();
+  if (!stdout) passthrough();
+
+  const result = safeParse(stdout.split(/\r?\n/).pop());
+  if (!result || result.handled !== true) passthrough();
+
+  process.stdout.write(
+    JSON.stringify({ decision: "block", reason: buildReason(result) }) + "\n"
+  );
+  process.exit(2);
+}
+
+main().catch(() => process.exit(0));

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "files": [
     "dist",
+    "hooks",
     "scripts/post-install.mjs",
     "README.md",
     "LICENSE"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { Command } from "commander";
 import { runRouter } from "./router/index.js";
+import { routeOnce } from "./router/route-once.js";
 import { startMcpServer } from "./mcp/server.js";
 import { runInit } from "./config/user-config.js";
 import { runSetup, runUninstall } from "./setup/index.js";
@@ -43,25 +44,45 @@ program
   });
 
 program
+  .command("route <input...>")
+  .description(
+    "Classify and execute a command with captured output; emit JSON (handled|unhandled). Used by the Claude Code Bash hook; safe for any integration that needs a one-shot router call without AI fallback."
+  )
+  .option("--cwd <dir>", "working directory (defaults to process.cwd())")
+  .action(async (input: string[], opts: { cwd?: string }) => {
+    const command = input.join(" ").trim();
+    const result = await routeOnce(command, { cwd: opts.cwd });
+    process.stdout.write(JSON.stringify(result) + "\n");
+    process.exit(0);
+  });
+
+program
   .command("setup")
   .description("Auto-install: detect AI tools, write shell shims into your rc file, register ninja mcp with MCP-capable clients, create config")
   .option("--shell <name>", "shell to target (bash|zsh|fish); auto-detect by default")
   .option("--tool <id>", "hook a specific tool (repeatable); default = all detected", collect, [])
   .option("--no-mcp", "skip auto-registering ninja mcp with Claude Code / Cursor / Claude Desktop")
+  .option("--no-hook", "skip installing the Claude Code PreToolUse Bash hook")
   .option("--quiet", "minimal output", false)
-  .action(async (opts: { shell?: string; tool: string[]; mcp: boolean; quiet: boolean }, cmd) => {
-    // The program-level `--dry-run` is hoisted by commander; merge so users
-    // can pass it either before or after the subcommand name.
-    const merged = cmd.optsWithGlobals();
-    const code = await runSetup({
-      shell: opts.shell,
-      tools: opts.tool,
-      dryRun: merged.dryRun === true,
-      noMcp: opts.mcp === false,
-      quiet: opts.quiet,
-    });
-    process.exit(code);
-  });
+  .action(
+    async (
+      opts: { shell?: string; tool: string[]; mcp: boolean; hook: boolean; quiet: boolean },
+      cmd
+    ) => {
+      // The program-level `--dry-run` is hoisted by commander; merge so users
+      // can pass it either before or after the subcommand name.
+      const merged = cmd.optsWithGlobals();
+      const code = await runSetup({
+        shell: opts.shell,
+        tools: opts.tool,
+        dryRun: merged.dryRun === true,
+        noMcp: opts.mcp === false,
+        noHook: opts.hook === false,
+        quiet: opts.quiet,
+      });
+      process.exit(code);
+    }
+  );
 
 program
   .command("uninstall")

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -4,11 +4,7 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import { loadRules } from "../rules/loader.js";
-import { classify } from "../router/classifier.js";
-import { execShell } from "../router/executor.js";
-import { validate } from "../safety/validator.js";
-import { recordHit, recordFallback, estimateTokensSaved } from "../telemetry/stats.js";
+import { routeOnce } from "../router/route-once.js";
 
 const TOOL_NAME = "maybe_execute_locally";
 
@@ -61,77 +57,9 @@ export async function startMcpServer(): Promise<void> {
       context?: { cwd?: string; ai_tool?: string };
     };
     const command = typeof args.command === "string" ? args.command : "";
-    if (!command.trim()) {
-      return {
-        content: [
-          { type: "text", text: JSON.stringify({ handled: false, reason: "empty_command" }) },
-        ],
-      };
-    }
-
-    const safety = validate(command);
-    if (!safety.allowed) {
-      await recordFallback("safety_block");
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify({
-              handled: false,
-              reason: "safety_block",
-              detail: safety.patternId,
-            }),
-          },
-        ],
-      };
-    }
-
-    const cwd = args.context?.cwd ?? process.cwd();
-    const rules = await loadRules();
-    const match = await classify(command, rules, { cwd });
-    if (!match) {
-      await recordFallback("no_match");
-      return {
-        content: [{ type: "text", text: JSON.stringify({ handled: false, reason: "no_match" }) }],
-      };
-    }
-
-    const safety2 = validate(match.command);
-    if (!safety2.allowed) {
-      await recordFallback("safety_block");
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify({
-              handled: false,
-              reason: "safety_block",
-              detail: safety2.patternId,
-            }),
-          },
-        ],
-      };
-    }
-
-    const result = await execShell(match.command, { cwd, captureOnly: true });
-    const tokens = estimateTokensSaved(command, result, match.rule);
-    await recordHit(match.rule, command, result);
-
+    const result = await routeOnce(command, { cwd: args.context?.cwd });
     return {
-      content: [
-        {
-          type: "text",
-          text: JSON.stringify({
-            handled: true,
-            stdout: result.stdout,
-            stderr: result.stderr,
-            exit_code: result.exitCode,
-            rule_id: match.rule.id,
-            matched_via: match.matchedVia,
-            tokens_saved_estimate: tokens,
-          }),
-        },
-      ],
+      content: [{ type: "text", text: JSON.stringify(result) }],
     };
   });
 

--- a/src/router/route-once.ts
+++ b/src/router/route-once.ts
@@ -1,0 +1,85 @@
+import { loadRules } from "../rules/loader.js";
+import { classify } from "./classifier.js";
+import { execShell } from "./executor.js";
+import { validate } from "../safety/validator.js";
+import {
+  estimateTokensSaved,
+  recordFallback,
+  recordHit,
+} from "../telemetry/stats.js";
+
+export interface RouteOnceOpts {
+  cwd?: string;
+}
+
+export type RouteOnceResult =
+  | {
+      handled: true;
+      stdout: string;
+      stderr: string;
+      exit_code: number;
+      rule_id: string;
+      matched_via: string;
+      tokens_saved_estimate: number;
+    }
+  | {
+      handled: false;
+      reason: "empty_command" | "safety_block" | "no_match";
+      detail?: string;
+    };
+
+/**
+ * One-shot classify-and-execute. Captures stdout/stderr without streaming
+ * (suitable for programmatic callers: MCP tool handler, Claude Code
+ * PreToolUse hook). Records telemetry. Never falls back to an AI tool.
+ */
+export async function routeOnce(
+  command: string,
+  opts: RouteOnceOpts = {}
+): Promise<RouteOnceResult> {
+  if (!command.trim()) {
+    return { handled: false, reason: "empty_command" };
+  }
+
+  const safety = validate(command);
+  if (!safety.allowed) {
+    await recordFallback("safety_block");
+    return {
+      handled: false,
+      reason: "safety_block",
+      detail: safety.patternId,
+    };
+  }
+
+  const cwd = opts.cwd ?? process.cwd();
+  const rules = await loadRules();
+  const match = await classify(command, rules, { cwd });
+  if (!match) {
+    await recordFallback("no_match");
+    return { handled: false, reason: "no_match" };
+  }
+
+  const safety2 = validate(match.command);
+  if (!safety2.allowed) {
+    await recordFallback("safety_block");
+    return {
+      handled: false,
+      reason: "safety_block",
+      detail: safety2.patternId,
+    };
+  }
+
+  const result = await execShell(match.command, { cwd, captureOnly: true });
+  const tokens = estimateTokensSaved(command, result, match.rule);
+  await recordHit(match.rule, command, result);
+
+  return {
+    handled: true,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    exit_code: result.exitCode,
+    rule_id: match.rule.id,
+    matched_via: match.matchedVia,
+    tokens_saved_estimate: tokens,
+  };
+}

--- a/src/setup/hook-install.ts
+++ b/src/setup/hook-install.ts
@@ -1,0 +1,269 @@
+import { copyFile, mkdir, readFile, rename, writeFile, access } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Claude Code PreToolUse Bash-hook installer.
+ *
+ * Writes a small entry into `~/.claude/settings.json` so every Bash tool call
+ * first consults `ninja route` — deterministic commands are answered locally
+ * and the Bash call is blocked. The merge is surgical: we keep every other
+ * hook, matcher, and top-level key intact, and back the file up once
+ * (`settings.json.token-ninja.bak`) before the first modification.
+ */
+
+const TOKEN_NINJA_MARKER = "token-ninja";
+
+export interface HookInstallResult {
+  path: string;
+  changed: boolean;
+  created: boolean;
+  backupPath: string | null;
+  skippedReason?: string;
+}
+
+export function claudeSettingsPath(
+  env: NodeJS.ProcessEnv = process.env,
+  home: string = homedir()
+): string {
+  return env.CLAUDE_SETTINGS_PATH ?? join(home, ".claude", "settings.json");
+}
+
+/**
+ * Absolute path to the shipped hook script (hooks/claude-code-bash.cjs at
+ * package root). Resolved off the compiled module location so it works when
+ * invoked from `dist/setup/hook-install.js` after `npm i -g`.
+ */
+export function hookScriptPath(): string {
+  const here = fileURLToPath(import.meta.url);
+  // dist layout: dist/setup/hook-install.js → ../../hooks/claude-code-bash.cjs
+  return resolve(dirname(here), "..", "..", "hooks", "claude-code-bash.cjs");
+}
+
+export function hookCommand(scriptPath: string = hookScriptPath()): string {
+  return `node ${JSON.stringify(scriptPath)}`;
+}
+
+interface HookEntry {
+  type?: string;
+  command?: string;
+  timeout?: number;
+}
+
+interface MatcherGroup {
+  matcher?: string;
+  hooks?: HookEntry[];
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+function isTokenNinjaCommand(cmd: unknown): boolean {
+  if (typeof cmd !== "string") return false;
+  return cmd.includes(TOKEN_NINJA_MARKER);
+}
+
+/**
+ * Merge our Bash PreToolUse hook into the parsed settings object. Returns a
+ * fresh copy and a `changed` flag. If an entry already points at the same
+ * script path, we leave the file alone. If there's a stale token-ninja entry
+ * with a different path (e.g. package upgraded), we rewrite it.
+ */
+export function mergeHookEntry(
+  existing: unknown,
+  scriptPath: string
+): { next: Record<string, unknown>; changed: boolean } {
+  const base: Record<string, unknown> = isObject(existing) ? { ...existing } : {};
+  const hooksRoot = isObject(base.hooks) ? { ...(base.hooks as Record<string, unknown>) } : {};
+  const preToolUseRaw = hooksRoot.PreToolUse;
+  const preToolUse: MatcherGroup[] = Array.isArray(preToolUseRaw)
+    ? (preToolUseRaw as MatcherGroup[]).map((g) => ({
+        matcher: g?.matcher,
+        hooks: Array.isArray(g?.hooks) ? [...g.hooks] : [],
+      }))
+    : [];
+
+  const desiredCommand = hookCommand(scriptPath);
+  const desiredHook: HookEntry = { type: "command", command: desiredCommand };
+
+  let changed = false;
+  let foundBashGroup = false;
+  for (const group of preToolUse) {
+    if (group.matcher !== "Bash") continue;
+    foundBashGroup = true;
+    const existingHooks = Array.isArray(group.hooks) ? group.hooks : [];
+    const tnIdx = existingHooks.findIndex((h) => isTokenNinjaCommand(h?.command));
+    if (tnIdx === -1) {
+      group.hooks = [desiredHook, ...existingHooks];
+      changed = true;
+    } else {
+      const prev = existingHooks[tnIdx];
+      if (!prev || prev.command !== desiredCommand) {
+        existingHooks[tnIdx] = { ...(prev ?? {}), ...desiredHook };
+        group.hooks = existingHooks;
+        changed = true;
+      }
+    }
+  }
+
+  if (!foundBashGroup) {
+    preToolUse.push({ matcher: "Bash", hooks: [desiredHook] });
+    changed = true;
+  }
+
+  if (!changed) {
+    return { next: base, changed: false };
+  }
+
+  hooksRoot.PreToolUse = preToolUse;
+  base.hooks = hooksRoot;
+  return { next: base, changed: true };
+}
+
+/**
+ * Remove our hook from the settings object. Drops empty matcher groups and
+ * empty `hooks.PreToolUse` / `hooks` containers so uninstall is a clean
+ * inverse of install.
+ */
+export function removeHookEntry(existing: unknown): {
+  next: Record<string, unknown>;
+  changed: boolean;
+} {
+  if (!isObject(existing)) return { next: {}, changed: false };
+  const base: Record<string, unknown> = { ...existing };
+  const hooksRoot = isObject(base.hooks) ? { ...(base.hooks as Record<string, unknown>) } : null;
+  if (!hooksRoot || !Array.isArray(hooksRoot.PreToolUse)) {
+    return { next: base, changed: false };
+  }
+
+  let changed = false;
+  const preToolUse: MatcherGroup[] = (hooksRoot.PreToolUse as MatcherGroup[])
+    .map((group) => {
+      const hooks = Array.isArray(group?.hooks) ? group.hooks : [];
+      const filtered = hooks.filter((h) => !isTokenNinjaCommand(h?.command));
+      if (filtered.length !== hooks.length) changed = true;
+      return { ...group, hooks: filtered };
+    })
+    .filter((group) => (group.hooks?.length ?? 0) > 0);
+
+  if (!changed) return { next: base, changed: false };
+
+  if (preToolUse.length === 0) {
+    delete hooksRoot.PreToolUse;
+  } else {
+    hooksRoot.PreToolUse = preToolUse;
+  }
+  if (Object.keys(hooksRoot).length === 0) {
+    delete base.hooks;
+  } else {
+    base.hooks = hooksRoot;
+  }
+  return { next: base, changed: true };
+}
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writeAtomic(path: string, content: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.token-ninja.tmp`;
+  await writeFile(tmp, content, "utf8");
+  await rename(tmp, path);
+}
+
+export interface InstallHookOpts {
+  path?: string;
+  scriptPath?: string;
+  dryRun?: boolean;
+}
+
+export async function installHook(opts: InstallHookOpts = {}): Promise<HookInstallResult> {
+  const path = opts.path ?? claudeSettingsPath();
+  const scriptPath = opts.scriptPath ?? hookScriptPath();
+  const existed = await fileExists(path);
+
+  let parsed: unknown = {};
+  if (existed) {
+    try {
+      const raw = await readFile(path, "utf8");
+      parsed = raw.trim() === "" ? {} : JSON.parse(raw);
+    } catch (err) {
+      return {
+        path,
+        changed: false,
+        created: false,
+        backupPath: null,
+        skippedReason: `could not parse ${path}: ${(err as Error).message}`,
+      };
+    }
+  }
+
+  const { next, changed } = mergeHookEntry(parsed, scriptPath);
+  if (!changed) {
+    return { path, changed: false, created: false, backupPath: null };
+  }
+
+  if (opts.dryRun) {
+    return { path, changed: true, created: !existed, backupPath: null };
+  }
+
+  let backupPath: string | null = null;
+  if (existed) {
+    const candidate = `${path}.token-ninja.bak`;
+    if (!(await fileExists(candidate))) {
+      try {
+        await copyFile(path, candidate);
+        backupPath = candidate;
+      } catch {
+        backupPath = null;
+      }
+    }
+  }
+
+  try {
+    await writeAtomic(path, JSON.stringify(next, null, 2) + "\n");
+  } catch (err) {
+    return {
+      path,
+      changed: false,
+      created: false,
+      backupPath,
+      skippedReason: `could not write ${path}: ${(err as Error).message}`,
+    };
+  }
+
+  return { path, changed: true, created: !existed, backupPath };
+}
+
+export async function uninstallHook(
+  opts: { path?: string } = {}
+): Promise<{ path: string; changed: boolean }> {
+  const path = opts.path ?? claudeSettingsPath();
+  if (!(await fileExists(path))) return { path, changed: false };
+
+  let parsed: unknown;
+  try {
+    const raw = await readFile(path, "utf8");
+    parsed = raw.trim() === "" ? {} : JSON.parse(raw);
+  } catch {
+    return { path, changed: false };
+  }
+
+  const { next, changed } = removeHookEntry(parsed);
+  if (!changed) return { path, changed: false };
+
+  try {
+    await writeAtomic(path, JSON.stringify(next, null, 2) + "\n");
+    return { path, changed: true };
+  } catch {
+    return { path, changed: false };
+  }
+}

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -7,6 +7,8 @@ import { detectShell, installBlock, uninstallBlock, rcFileFor } from "./shell-in
 import type { ShellName } from "./shell-install.js";
 import { installMcp, uninstallMcp } from "./mcp-install.js";
 import type { McpInstallResult } from "./mcp-install.js";
+import { installHook, uninstallHook } from "./hook-install.js";
+import type { HookInstallResult } from "./hook-install.js";
 import { logger } from "../utils/logger.js";
 
 export interface SetupOpts {
@@ -20,6 +22,8 @@ export interface SetupOpts {
   dryRun?: boolean;
   /** Skip auto-registering `ninja mcp` with Claude Code / Cursor / Claude Desktop. */
   noMcp?: boolean;
+  /** Skip installing the Claude Code PreToolUse Bash hook. */
+  noHook?: boolean;
 }
 
 function normalizeShell(s: string | undefined): ShellName {
@@ -94,6 +98,16 @@ export async function runSetup(opts: SetupOpts = {}): Promise<number> {
         }
       }
     }
+    if (!opts.noHook) {
+      const hook = await installHook({ dryRun: true });
+      if (hook.changed) {
+        process.stdout.write(
+          `[dry-run] would install Claude Code Bash hook in ${hook.path}${hook.created ? " (create)" : ""}\n`
+        );
+      } else if (hook.skippedReason) {
+        process.stdout.write(`[dry-run] skip Bash hook: ${hook.skippedReason}\n`);
+      }
+    }
     return 0;
   }
 
@@ -101,6 +115,7 @@ export async function runSetup(opts: SetupOpts = {}): Promise<number> {
   await ensureConfig(hooked[0]);
 
   const mcpResults: McpInstallResult[] = opts.noMcp ? [] : await installMcp();
+  const hookResult: HookInstallResult | null = opts.noHook ? null : await installHook();
 
   if (!opts.quiet) {
     const lines = [
@@ -126,6 +141,18 @@ export async function runSetup(opts: SetupOpts = {}): Promise<number> {
       }
     }
 
+    if (hookResult) {
+      if (hookResult.changed) {
+        lines.push(
+          `  bash hook   : installed Claude Code PreToolUse hook (${hookResult.path})${hookResult.created ? " [created]" : ""}`
+        );
+      } else if (hookResult.skippedReason) {
+        lines.push(`  bash hook   : skipped — ${hookResult.skippedReason}`);
+      } else {
+        lines.push(`  bash hook   : already installed`);
+      }
+    }
+
     lines.push(``);
     lines.push(`Open a new terminal (or: source ${result.rcFile}) and use your AI tool normally.`);
     lines.push(`Commands token-ninja recognizes run locally; everything else passes through.`);
@@ -140,6 +167,7 @@ export async function runUninstall(opts: { shell?: string; quiet?: boolean } = {
   const shell = normalizeShell(opts.shell);
   const result = await uninstallBlock(shell);
   const mcp = await uninstallMcp();
+  const hook = await uninstallHook();
   if (!opts.quiet) {
     if (result.changed) {
       process.stdout.write(`token-ninja: removed managed block from ${result.rcFile}\n`);
@@ -150,6 +178,9 @@ export async function runUninstall(opts: { shell?: string; quiet?: boolean } = {
     const unregistered = mcp.filter((r) => r.changed).map((r) => r.target.label);
     if (unregistered.length > 0) {
       process.stdout.write(`token-ninja: removed MCP entry from ${unregistered.join(", ")}\n`);
+    }
+    if (hook.changed) {
+      process.stdout.write(`token-ninja: removed Bash hook from ${hook.path}\n`);
     }
   }
   return 0;

--- a/tests/hook-install.test.ts
+++ b/tests/hook-install.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  hookCommand,
+  installHook,
+  mergeHookEntry,
+  removeHookEntry,
+  uninstallHook,
+} from "../src/setup/hook-install.js";
+
+const SCRIPT = "/opt/token-ninja/hooks/claude-code-bash.cjs";
+
+describe("mergeHookEntry", () => {
+  it("adds a Bash matcher group when none exists", () => {
+    const { next, changed } = mergeHookEntry({}, SCRIPT);
+    expect(changed).toBe(true);
+    const pre = (next.hooks as Record<string, unknown>).PreToolUse as Array<{
+      matcher: string;
+      hooks: Array<{ type: string; command: string }>;
+    }>;
+    expect(pre).toHaveLength(1);
+    expect(pre[0]!.matcher).toBe("Bash");
+    expect(pre[0]!.hooks[0]!.command).toBe(hookCommand(SCRIPT));
+  });
+
+  it("preserves other matcher groups and other hooks inside the Bash group", () => {
+    const existing = {
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "Write|Edit",
+            hooks: [{ type: "command", command: "node other-guard.js" }],
+          },
+          {
+            matcher: "Bash",
+            hooks: [{ type: "command", command: "bash unrelated.sh" }],
+          },
+        ],
+        PostToolUse: [
+          { matcher: "Bash", hooks: [{ type: "command", command: "bash after.sh" }] },
+        ],
+      },
+      statusLine: { type: "command", command: "echo hi" },
+    };
+    const { next, changed } = mergeHookEntry(existing, SCRIPT);
+    expect(changed).toBe(true);
+
+    expect((next as typeof existing).statusLine).toEqual({ type: "command", command: "echo hi" });
+    const hooksRoot = next.hooks as Record<string, unknown>;
+    const post = hooksRoot.PostToolUse as unknown[];
+    expect(post).toEqual(existing.hooks.PostToolUse);
+
+    const pre = hooksRoot.PreToolUse as Array<{
+      matcher: string;
+      hooks: Array<{ type: string; command: string }>;
+    }>;
+    const writeEdit = pre.find((g) => g.matcher === "Write|Edit")!;
+    expect(writeEdit.hooks).toEqual([{ type: "command", command: "node other-guard.js" }]);
+
+    const bash = pre.find((g) => g.matcher === "Bash")!;
+    expect(bash.hooks.map((h) => h.command)).toEqual([
+      hookCommand(SCRIPT),
+      "bash unrelated.sh",
+    ]);
+  });
+
+  it("is idempotent when the same command is already present", () => {
+    const first = mergeHookEntry({}, SCRIPT);
+    const second = mergeHookEntry(first.next, SCRIPT);
+    expect(second.changed).toBe(false);
+  });
+
+  it("updates a stale token-ninja command when the script path has drifted", () => {
+    const stale = {
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "Bash",
+            hooks: [{ type: "command", command: "node /old/path/token-ninja/hook.cjs" }],
+          },
+        ],
+      },
+    };
+    const { next, changed } = mergeHookEntry(stale, SCRIPT);
+    expect(changed).toBe(true);
+    const bash = ((next.hooks as Record<string, unknown>).PreToolUse as Array<{
+      matcher: string;
+      hooks: Array<{ command: string }>;
+    }>).find((g) => g.matcher === "Bash")!;
+    expect(bash.hooks).toHaveLength(1);
+    expect(bash.hooks[0]!.command).toBe(hookCommand(SCRIPT));
+  });
+
+  it("treats non-object input as empty config", () => {
+    const { next, changed } = mergeHookEntry(null, SCRIPT);
+    expect(changed).toBe(true);
+    const pre = (next.hooks as Record<string, unknown>).PreToolUse as unknown[];
+    expect(pre).toHaveLength(1);
+  });
+});
+
+describe("removeHookEntry", () => {
+  it("removes our hook but leaves other entries intact", () => {
+    const existing = {
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "Bash",
+            hooks: [
+              { type: "command", command: hookCommand(SCRIPT) },
+              { type: "command", command: "bash unrelated.sh" },
+            ],
+          },
+          {
+            matcher: "Write|Edit",
+            hooks: [{ type: "command", command: "node other-guard.js" }],
+          },
+        ],
+      },
+    };
+    const { next, changed } = removeHookEntry(existing);
+    expect(changed).toBe(true);
+    const pre = (next.hooks as Record<string, unknown>).PreToolUse as Array<{
+      matcher: string;
+      hooks: Array<{ command: string }>;
+    }>;
+    const bash = pre.find((g) => g.matcher === "Bash")!;
+    expect(bash.hooks.map((h) => h.command)).toEqual(["bash unrelated.sh"]);
+    expect(pre.find((g) => g.matcher === "Write|Edit")).toBeTruthy();
+  });
+
+  it("drops an empty Bash group and the PreToolUse array when ours was the only hook", () => {
+    const existing = {
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "Bash",
+            hooks: [{ type: "command", command: hookCommand(SCRIPT) }],
+          },
+        ],
+      },
+    };
+    const { next, changed } = removeHookEntry(existing);
+    expect(changed).toBe(true);
+    expect((next as { hooks?: unknown }).hooks).toBeUndefined();
+  });
+
+  it("is a no-op when our hook isn't present", () => {
+    const { changed } = removeHookEntry({
+      hooks: { PreToolUse: [{ matcher: "Bash", hooks: [] }] },
+    });
+    expect(changed).toBe(false);
+  });
+});
+
+describe("installHook / uninstallHook", () => {
+  let dir = "";
+  let path = "";
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "tn-hook-"));
+    path = join(dir, "settings.json");
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("creates settings.json when it doesn't exist", async () => {
+    const r = await installHook({ path, scriptPath: SCRIPT });
+    expect(r.changed).toBe(true);
+    expect(r.created).toBe(true);
+    const parsed = JSON.parse(await readFile(path, "utf8"));
+    const pre = parsed.hooks.PreToolUse as Array<{ matcher: string; hooks: Array<{ command: string }> }>;
+    expect(pre[0]!.matcher).toBe("Bash");
+    expect(pre[0]!.hooks[0]!.command).toBe(hookCommand(SCRIPT));
+  });
+
+  it("preserves other settings when merging into an existing file", async () => {
+    await writeFile(
+      path,
+      JSON.stringify({
+        hooks: {
+          PreToolUse: [
+            { matcher: "Write|Edit", hooks: [{ type: "command", command: "node x.js" }] },
+          ],
+        },
+        theme: "dark",
+      }),
+      "utf8"
+    );
+    const r = await installHook({ path, scriptPath: SCRIPT });
+    expect(r.changed).toBe(true);
+    const parsed = JSON.parse(await readFile(path, "utf8"));
+    expect(parsed.theme).toBe("dark");
+    const pre = parsed.hooks.PreToolUse as Array<{ matcher: string }>;
+    expect(pre.find((g) => g.matcher === "Write|Edit")).toBeTruthy();
+    expect(pre.find((g) => g.matcher === "Bash")).toBeTruthy();
+  });
+
+  it("is idempotent and backs up only once", async () => {
+    await writeFile(path, JSON.stringify({ hooks: {} }), "utf8");
+    const first = await installHook({ path, scriptPath: SCRIPT });
+    expect(first.changed).toBe(true);
+    expect(first.backupPath).toBe(`${path}.token-ninja.bak`);
+    const second = await installHook({ path, scriptPath: SCRIPT });
+    expect(second.changed).toBe(false);
+    expect(second.backupPath).toBeNull();
+  });
+
+  it("skips safely when settings.json is malformed", async () => {
+    await writeFile(path, "{not json", "utf8");
+    const r = await installHook({ path, scriptPath: SCRIPT });
+    expect(r.changed).toBe(false);
+    expect(r.skippedReason).toMatch(/could not parse/);
+    expect(await readFile(path, "utf8")).toBe("{not json");
+  });
+
+  it("dry-run does not write", async () => {
+    const r = await installHook({ path, scriptPath: SCRIPT, dryRun: true });
+    expect(r.changed).toBe(true);
+    await expect(readFile(path, "utf8")).rejects.toBeTruthy();
+  });
+
+  it("uninstall removes our hook and leaves the rest of the file in place", async () => {
+    await installHook({ path, scriptPath: SCRIPT });
+    // Add an unrelated entry after install, to make sure we don't nuke it.
+    const before = JSON.parse(await readFile(path, "utf8"));
+    before.theme = "dark";
+    before.hooks.PreToolUse.push({
+      matcher: "Write|Edit",
+      hooks: [{ type: "command", command: "node x.js" }],
+    });
+    await writeFile(path, JSON.stringify(before), "utf8");
+
+    const r = await uninstallHook({ path });
+    expect(r.changed).toBe(true);
+    const after = JSON.parse(await readFile(path, "utf8"));
+    expect(after.theme).toBe("dark");
+    const pre = (after.hooks?.PreToolUse ?? []) as Array<{ matcher: string }>;
+    expect(pre.find((g) => g.matcher === "Bash")).toBeFalsy();
+    expect(pre.find((g) => g.matcher === "Write|Edit")).toBeTruthy();
+  });
+
+  it("uninstall is a no-op when settings.json is missing", async () => {
+    const r = await uninstallHook({ path: join(dir, "does-not-exist.json") });
+    expect(r.changed).toBe(false);
+  });
+});

--- a/tests/hook-script.test.ts
+++ b/tests/hook-script.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const HOOK = resolve(HERE, "..", "hooks", "claude-code-bash.cjs");
+
+function runHook(input: unknown, env: NodeJS.ProcessEnv) {
+  return spawnSync(process.execPath, [HOOK], {
+    input: JSON.stringify(input),
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+    timeout: 15000,
+  });
+}
+
+describe("Claude Code Bash hook script", () => {
+  let dir = "";
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "tn-hook-script-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  async function writeFakeNinja(response: unknown): Promise<string> {
+    const script = join(dir, "ninja");
+    // The fake `ninja` ignores its args and prints the canned JSON.
+    await writeFile(
+      script,
+      `#!/usr/bin/env node\nprocess.stdout.write(${JSON.stringify(JSON.stringify(response))} + "\\n");\n`,
+      "utf8"
+    );
+    await chmod(script, 0o755);
+    return script;
+  }
+
+  it("exits 0 when tool_name is not Bash", async () => {
+    await writeFakeNinja({ handled: true, stdout: "nope", exit_code: 0, rule_id: "x", tokens_saved_estimate: 1 });
+    const r = runHook(
+      { tool_name: "Edit", tool_input: { command: "anything" } },
+      { PATH: `${dir}:${process.env.PATH ?? ""}` }
+    );
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe("");
+  });
+
+  it("exits 0 when ninja reports handled=false", async () => {
+    await writeFakeNinja({ handled: false, reason: "no_match" });
+    const r = runHook(
+      { tool_name: "Bash", tool_input: { command: "xyzzy" } },
+      { PATH: `${dir}:${process.env.PATH ?? ""}` }
+    );
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe("");
+  });
+
+  it("blocks Bash with decision=block and includes stdout/rule/tokens when handled", async () => {
+    await writeFakeNinja({
+      handled: true,
+      stdout: "On branch main\n",
+      stderr: "",
+      exit_code: 0,
+      rule_id: "git-status",
+      tokens_saved_estimate: 512,
+      matched_via: "exact",
+    });
+    const r = runHook(
+      { tool_name: "Bash", tool_input: { command: "git status" } },
+      { PATH: `${dir}:${process.env.PATH ?? ""}` }
+    );
+    expect(r.status).toBe(2);
+    const parsed = JSON.parse(r.stdout.trim());
+    expect(parsed.decision).toBe("block");
+    expect(parsed.reason).toMatch(/git-status/);
+    expect(parsed.reason).toMatch(/On branch main/);
+    expect(parsed.reason).toMatch(/512/);
+  });
+
+  it("fails open (exit 0) when ninja isn't on PATH", async () => {
+    const r = runHook(
+      { tool_name: "Bash", tool_input: { command: "git status" } },
+      { PATH: dir } // dir has no `ninja` binary
+    );
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe("");
+  });
+
+  it("fails open when stdin isn't valid JSON", async () => {
+    await writeFakeNinja({ handled: true, stdout: "x", exit_code: 0, rule_id: "x", tokens_saved_estimate: 1 });
+    const r = spawnSync(process.execPath, [HOOK], {
+      input: "this is not json",
+      env: { ...process.env, PATH: `${dir}:${process.env.PATH ?? ""}` },
+      encoding: "utf8",
+      timeout: 10000,
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe("");
+  });
+});

--- a/tests/route-once.test.ts
+++ b/tests/route-once.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { routeOnce } from "../src/router/route-once.js";
+
+describe("routeOnce", () => {
+  it("returns empty_command for whitespace input", async () => {
+    const r = await routeOnce("   ");
+    expect(r.handled).toBe(false);
+    if (!r.handled) expect(r.reason).toBe("empty_command");
+  });
+
+  it("returns safety_block when the raw input trips the deny-list", async () => {
+    const r = await routeOnce("rm -rf /");
+    expect(r.handled).toBe(false);
+    if (!r.handled) expect(r.reason).toBe("safety_block");
+  });
+
+  it("returns no_match for gibberish", async () => {
+    const r = await routeOnce("xyzzy-unmatchable-input arg arg");
+    expect(r.handled).toBe(false);
+    if (!r.handled) expect(r.reason).toBe("no_match");
+  });
+
+  it("executes a matched read-only rule and captures stdout", async () => {
+    // `git status` is one of the most reliable built-ins and safe to run in
+    // any git repo (the token-ninja repo itself qualifies).
+    const r = await routeOnce("git status");
+    expect(r.handled).toBe(true);
+    if (r.handled) {
+      expect(typeof r.rule_id).toBe("string");
+      expect(r.rule_id.length).toBeGreaterThan(0);
+      expect(typeof r.stdout).toBe("string");
+      expect(typeof r.exit_code).toBe("number");
+      expect(typeof r.tokens_saved_estimate).toBe("number");
+    }
+  });
+});


### PR DESCRIPTION
Claude Code's built-in Bash tool is separate from its MCP tool list, so the model bypasses `maybe_execute_locally` and runs shell commands directly — costing tokens on deterministic calls like `git status`.

Install a PreToolUse Bash hook into `~/.claude/settings.json` that shells out to a new `ninja route` subcommand. On a rule match, the hook blocks Bash with `decision:"block"` and returns the captured output as the reason, so Claude answers the user without the Bash tool ever firing. On misses or any unexpected error, the hook exits 0 and Bash proceeds normally — never a single point of failure.

- new `ninja route` subcommand emits one-shot JSON (handled|unhandled), shared with the MCP server via `routeOnce()`
- `hooks/claude-code-bash.cjs` ships in the npm tarball
- `src/setup/hook-install.ts` merges/removes the hook surgically: other matcher groups, other Bash hooks, and unrelated top-level keys are preserved; the file is backed up once before the first write
- `ninja setup --no-hook` opts out; `ninja uninstall` reverses everything
- 29 new tests covering merge logic, install/uninstall round-trip, hook script spawn, and the route subcommand; 258 total (was 229)

## Summary

<!-- What does this PR do? Link any issues it addresses. -->

## Changes

- [ ] New rule(s) — domain: _______
- [ ] New deny pattern — id: _______
- [ ] Classifier / safety / router change
- [ ] Docs / tooling

## Testing

- [ ] `npm run typecheck` passes
- [ ] `npm test` passes
- [ ] Added fixture lines to `tests/fixtures/real-commands.txt` (if new rules)
- [ ] Added deny-list test (if new deny pattern)

## Safety

<!-- If this PR touches safety/, explain what could bypass the new patterns
and what you tried. -->
