### PR TITLE
ci(release): drop --provenance and add workflow_dispatch publish gate

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,11 +3,16 @@ name: release-please
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish current package.json version to npm (bypasses release-please)"
+        type: boolean
+        default: false
 
 permissions:
   contents: write
   pull-requests: write
-  id-token: write
 
 jobs:
   release-please:
@@ -15,38 +20,48 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
+        if: github.event_name == 'push'
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      - name: Decide whether to publish
+        id: gate
+        run: |
+          if [[ "${{ steps.release.outputs.release_created }}" == "true" ]] || [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.publish }}" == "true" ]]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v4
-        if: ${{ steps.release.outputs.release_created }}
+        if: steps.gate.outputs.publish == 'true'
 
       - uses: actions/setup-node@v4
-        if: ${{ steps.release.outputs.release_created }}
+        if: steps.gate.outputs.publish == 'true'
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
           cache: npm
 
       - run: npm ci --no-audit --no-fund
-        if: ${{ steps.release.outputs.release_created }}
+        if: steps.gate.outputs.publish == 'true'
 
       - run: npm run lint
-        if: ${{ steps.release.outputs.release_created }}
+        if: steps.gate.outputs.publish == 'true'
 
       - run: npm run typecheck
-        if: ${{ steps.release.outputs.release_created }}
+        if: steps.gate.outputs.publish == 'true'
 
       - run: npm test
-        if: ${{ steps.release.outputs.release_created }}
+        if: steps.gate.outputs.publish == 'true'
         env:
           CI: "true"
 
       - run: npm run build
-        if: ${{ steps.release.outputs.release_created }}
+        if: steps.gate.outputs.publish == 'true'
 
-      - run: npm publish --provenance --access public
-        if: ${{ steps.release.outputs.release_created }}
+      - run: npm publish --access public
+        if: steps.gate.outputs.publish == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Provenance requires both OIDC trust config on npmjs and a token with id-token exchange -- neither is set up, and the post-merge run for v0.2.0 silently failed at the publish step. Drop --provenance and the matching id-token: write permission; plain --access public publishes work with the NPM_TOKEN secret alone.

Add workflow_dispatch with a `publish` boolean input so we can ship the already-tagged v0.2.0 (release-please won't re-fire on a commit whose release already exists). Both release_created and manual dispatch flow through a single gate step, so the lint/test/build/ publish chain stays DRY.

https://claude.ai/code/session_016Zo5DbW7W6URHQZz2kbpsm

## Summary

<!-- What does this PR do? Link any issues it addresses. -->

## Changes

- [ ] New rule(s) — domain: _______
- [ ] New deny pattern — id: _______
- [ ] Classifier / safety / router change
- [ ] Docs / tooling

## Testing

- [ ] `npm run typecheck` passes
- [ ] `npm test` passes
- [ ] Added fixture lines to `tests/fixtures/real-commands.txt` (if new rules)
- [ ] Added deny-list test (if new deny pattern)

## Safety

<!-- If this PR touches safety/, explain what could bypass the new patterns
and what you tried. -->
