### PR TITLE
Update repository URLs to oanhduong GitHub organization

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
   ],
   "license": "MIT",
   "author": "token-ninja contributors",
-  "homepage": "https://github.com/token-ninja/token-ninja#readme",
+  "homepage": "https://github.com/oanhduong/token-ninja#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/token-ninja/token-ninja.git"
+    "url": "https://github.com/oanhduong/token-ninja.git"
   },
   "bugs": {
-    "url": "https://github.com/token-ninja/token-ninja/issues"
+    "url": "https://github.com/oanhduong/token-ninja/issues"
   },
   "type": "module",
   "main": "dist/cli.js",


### PR DESCRIPTION
## Summary

Updates package.json repository metadata to point to the `oanhduong` GitHub organization instead of `token-ninja`.

## Changes

- [ ] New rule(s) — domain: _______
- [ ] New deny pattern — id: _______
- [ ] Classifier / safety / router change
- [x] Docs / tooling

## Testing

N/A — Configuration metadata update only.

## Safety

N/A

https://claude.ai/code/session_01BB2642wbLafiyk7GNx5HqB