### PR TITLE
chore: release the security fix as 0.6.0, not 0.5.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,10 @@ npm run typecheck        # tsc --noEmit
 
 1. `npm run lint && npm run typecheck && npm test && npm run test:coverage`
 2. Bump version in `package.json` only — `src/version.ts` reads it and
-   `cli.ts` / `mcp/server.ts` / `doctor/` import from there.
+   `cli.ts` / `mcp/server.ts` / `doctor/` import from there. In practice
+   release-please does this; only override it with `release-as` in
+   `release-please-config.json`, and **remove that key right after the
+   release ships** or every later release is pinned to the same version.
 3. Update `CHANGELOG.md`.
 4. `npm run build`
 5. `npm pack --dry-run` — confirm `dist/`, `README.md`, `LICENSE` are in.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ gets out of the way for everything else.
 - [Configuration](#configuration)
 - [Safety model](#safety-model)
 - [Platform support](#platform-support)
+- [Upgrading from 0.5.x](#upgrading-from-05x)
 - [Commands](#commands)
 - [Benchmarks](#benchmarks)
 - [Development](#development)
@@ -688,6 +689,40 @@ The package still compiles and packs on Windows in CI so the win32 code paths
 in `src/` cannot rot, and the MCP server itself is portable — a Windows user
 can register `ninja mcp` by hand and use the tool through their AI client
 without the shell shim.
+
+## Upgrading from 0.5.x
+
+0.6.0 fixes a security bug and changes four behaviours you may be relying on.
+
+**1. A rejected command can no longer reach a shell.** Through 0.5.1 the AI
+fallback interpolated your input into a shell command unquoted, so a command
+the safety validator had just *blocked* executed anyway one process later.
+Upgrade for this reason if for no other.
+
+**2. `npm install -g` no longer configures anything.** Run `ninja setup`
+yourself afterwards (`ninja doctor` to verify). Set `TOKEN_NINJA_AUTO_SETUP=1`
+before installing to keep the old behaviour.
+
+**3. Deep imports are gone.** The package now has an `exports` map and a real
+library entry, so importing it no longer executes the CLI:
+
+```diff
+- import { routeOnce } from "token-ninja/dist/router/route-once.js";
++ import { routeOnce } from "token-ninja";
+```
+
+Any other `token-ninja/dist/...` path now fails with
+`ERR_PACKAGE_PATH_NOT_EXPORTED`. The root export ships TypeScript
+declarations.
+
+**4. Command substitution falls back to the AI.** Commands containing `$(…)`,
+backticks or `<(…)` are refused locally, because nothing textual can predict
+what they expand to. They are passed to your AI tool instead of being run —
+so a command that used to execute locally may now cost tokens.
+
+Also new: `exec.timeout_ms` and `exec.max_output_bytes` bound every local
+command (see [Configuration](#configuration)), and `custom_rules_dir` /
+`stats.enabled` finally do what the docs always said they did.
 
 ## Commands
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
   "packages": {
     ".": {
       "package-name": "token-ninja",
+      "release-as": "0.6.0",
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": true,
       "include-component-in-tag": false,


### PR DESCRIPTION
## Summary

Nothing is on npm yet — `latest` is still **0.5.1**, the version with the fallback injection bug. Release PR #19 is open and would publish **0.5.2**.

0.5.2 is the wrong number. The #18 squash-merge landed as one `fix:` commit, so release-please computed a patch bump, but three documented behaviours change in it. A patch version tells users the upgrade is safe to take blindly, and npm versions are immutable — worth getting right before publishing, not after.

Verified against a real consumer install of the merged `main`:

```
import("token-ninja/dist/router/route-once.js")  →  ERR_PACKAGE_PATH_NOT_EXPORTED
import("token-ninja")                            →  resolves, 21 exports
```

That deep path was in the README as *the* supported way to use the router programmatically, so anyone following the docs breaks on upgrade.

## Changes

- [ ] New rule(s) — domain: _n/a_
- [ ] New deny pattern — id: _n/a_
- [ ] Classifier / safety / router change
- [x] Docs / tooling

- `release-as: 0.6.0` in `release-please-config.json`, so #19 regenerates as 0.6.0. Chosen over a `BREAKING CHANGE:` commit footer because this repo squash-merges and a footer may not survive into the squash message; a config file always does.
- A README **Upgrading from 0.5.x** section covering the four things a user can trip over: the security fix, `npm install -g` no longer running setup, deep imports being gone, and `$(…)` commands now falling back to the AI instead of running locally.
- The 0.6.0 references already written into README and SECURITY.md by #18 now match what ships. At 0.5.2 they would simply have been wrong.

No source changes.

## Testing

- [x] `npm run typecheck` passes — no source touched
- [x] `npm test` passes — unchanged, 398 tests
- [x] Added fixture lines to `tests/fixtures/real-commands.txt` (if new rules) — n/a
- [x] Added deny-list test (if new deny pattern) — n/a

`npm run lint` and `npm run rule-stats:check` pass. The deep-import claim above was verified by installing the built package into a scratch consumer project, not inferred from the `exports` map.

## Safety

No change to `safety/`. The security content ships in #18; this only decides the number it ships under.

**One thing to clean up:** `release-as` pins *every* later release to 0.6.0, not just the next one. Remove it once 0.6.0 is published. The release checklist in `CLAUDE.md` now says so, and I can send that removal PR as soon as the release lands.

## Merge order

1. Merge this PR.
2. release-please updates #19 from 0.5.2 → 0.6.0.
3. Merge #19 → the release workflow publishes 0.6.0 to npm and tags `v0.6.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnqRHdfanRgE7pT7vQztWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01WnqRHdfanRgE7pT7vQztWY)_