### PR TITLE
fix(ci): remove the release-as pin that was silently skipping npm publish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,9 +178,20 @@ npm run typecheck        # tsc --noEmit
 1. `npm run lint && npm run typecheck && npm test && npm run test:coverage`
 2. Bump version in `package.json` only — `src/version.ts` reads it and
    `cli.ts` / `mcp/server.ts` / `doctor/` import from there. In practice
-   release-please does this; only override it with `release-as` in
-   `release-please-config.json`, and **remove that key right after the
-   release ships** or every later release is pinned to the same version.
+   release-please does this.
+
+   Avoid `release-as` in `release-please-config.json`. Once `main` reaches
+   the pinned version, release-please computes "next = same version", never
+   sets `release_created`, and opens a fresh release PR on every push instead
+   of cutting a release — so the publish step in `release-please.yml` is
+   silently skipped and the run still reports success. To force a specific
+   version, prefer a `Release-As:` footer on one commit; if you must use the
+   config key, remove it in the very same release PR.
+
+   To publish a version release-please will not cut (a recovery path, not a
+   routine): Actions → release-please → Run workflow → `publish: true`. That
+   runs lint, typecheck, tests and build, then publishes whatever version
+   `package.json` on `main` holds.
 3. Update `CHANGELOG.md`.
 4. `npm run build`
 5. `npm pack --dry-run` — confirm `dist/`, `README.md`, `LICENSE` are in.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,6 @@
   "packages": {
     ".": {
       "package-name": "token-ninja",
-      "release-as": "0.6.0",
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": true,
       "include-component-in-tag": false,


### PR DESCRIPTION
## Summary

npm has **not** received 0.6.0. Straight from the registry, no cache:

```
dist-tags: {"latest":"0.5.1"}
versions:  0.1.0 … 0.5.1
modified:  2026-04-22T10:35:18.964Z
```

Untouched since April — while `main` sits at 0.6.0 and tag `v0.6.0` exists. Both release-please runs reported **success**, which is why this looked fine.

The gate step printed the reason verbatim:

```
if [[ "" == "true" ]] || [[ "push" == "workflow_dispatch" && "" == "true" ]]
```

`release_created` was empty → `publish=false` → all eight publish steps **skipped**, job green.

**Why it was empty:** `release-as: 0.6.0` forces the version but never clears itself. Once main reached 0.6.0, every run computed "next = 0.6.0", found nothing to advance, and opened *another* release PR instead of cutting a release — #21, then #22, and it would have kept going indefinitely.

That pin was mine, added in #20 to get 0.6.0 instead of 0.5.2. It did its job and then became the blocker; I flagged it needed removing but not that leaving it would break publishing outright.

## Changes

- [ ] New rule(s) — domain: _n/a_
- [ ] New deny pattern — id: _n/a_
- [ ] Classifier / safety / router change
- [x] Docs / tooling

- Remove `release-as` from `release-please-config.json`, ending the release-PR loop.
- `CLAUDE.md` release checklist now records why not to reach for `release-as` (it fails *silently* — green run, no publish), suggests a `Release-As:` commit footer instead, and documents the manual publish path.

No source changes.

## Testing

- [x] `npm run typecheck` passes — no source touched
- [x] `npm test` passes — unchanged
- [x] Added fixture lines to `tests/fixtures/real-commands.txt` (if new rules) — n/a
- [x] Added deny-list test (if new deny pattern) — n/a

`npm run rule-stats:check` passes.

## Safety

No change to `safety/`.

**This PR does not publish 0.6.0.** As far as release-please is concerned 0.6.0 is already released — tagged, changelogged, manifest updated — so nothing will re-cut it. Removing the pin only stops the loop.

To actually publish, use the escape hatch already in the workflow, which reads `package.json` directly and ignores release-please state:

> **Actions → release-please → Run workflow → `publish: true`**

It runs lint, typecheck, tests and build first, then `npm publish` of main's version — 0.6.0. I could not trigger it myself (`403 Resource not accessible by integration`).

Order does not matter; the two are independent. Merging this first just stops more release PRs appearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnqRHdfanRgE7pT7vQztWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01WnqRHdfanRgE7pT7vQztWY)_